### PR TITLE
fix(meta): correct PyPI author name and sync version

### DIFF
--- a/attestix/__init__.py
+++ b/attestix/__init__.py
@@ -18,7 +18,7 @@ Modules:
     - attestix.blockchain: Merkle trees and EAS anchoring
 """
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 # Re-export submodules for convenient access
 from attestix import services

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 authors = [
-    {name = "VibeTensor Inc.", email = "hello@vibetensor.com"},
+    {name = "VIBETENSOR PRIVATE LIMITED", email = "hello@vibetensor.com"},
 ]
 keywords = [
     "attestix",


### PR DESCRIPTION
## Summary
- Update author from "VibeTensor Inc." to "VIBETENSOR PRIVATE LIMITED" in pyproject.toml to match registered company name
- Sync `__init__.py` version from 0.2.3 to 0.2.4 to match pyproject.toml

## Context
PyPI listing currently shows incorrect company name. This needs to be corrected before any investor/evaluator checks the package metadata.

## Test plan
- [ ] Verify pyproject.toml author field reads "VIBETENSOR PRIVATE LIMITED"
- [ ] Verify attestix/__init__.py __version__ matches pyproject.toml version
- [ ] After merge, tag and release to update PyPI metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.4
  * Updated project author metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->