### PR TITLE
security: CRITICAL fix delegation chain auth bypass - verify parent tokens and capability attenuation

### DIFF
--- a/services/delegation_service.py
+++ b/services/delegation_service.py
@@ -39,8 +39,50 @@ class DelegationService:
             capabilities: List of capability strings being delegated.
             expiry_hours: How long the delegation is valid.
             parent_token: Optional parent delegation token for chaining.
+
+        Security:
+            When parent_token is provided, the parent is fully verified
+            (signature, expiry, revocation, and recursively its own prf
+            chain) BEFORE a new delegation is issued. The requested
+            capabilities must also be a subset of the parent's att
+            (UCAN capability attenuation). This prevents chain forgery
+            and capability escalation attacks.
         """
         try:
+            # Verify parent delegation and enforce capability attenuation
+            # before issuing a new token. This is critical: without this
+            # check, any caller could supply an arbitrary string as a
+            # parent and claim delegated authority they never received.
+            if parent_token is not None:
+                parent_result = self.verify_delegation(parent_token)
+                if not parent_result.get("valid"):
+                    return {
+                        "error": (
+                            "Invalid parent delegation: "
+                            f"{parent_result.get('reason', 'unknown reason')}"
+                        )
+                    }
+
+                # Explicitly reject expired parents even if the JWT
+                # library did not raise (belt and suspenders).
+                if parent_result.get("expired"):
+                    return {"error": "Invalid parent delegation: parent token has expired"}
+
+                # Capability attenuation: a child delegation may only
+                # grant a subset of the parent's capabilities. Issuing
+                # capabilities not held by the parent is a privilege
+                # escalation and must be rejected.
+                parent_caps = set(parent_result.get("capabilities") or [])
+                requested_caps = set(capabilities or [])
+                if not requested_caps.issubset(parent_caps):
+                    escalated = sorted(requested_caps - parent_caps)
+                    return {
+                        "error": (
+                            "Capability escalation denied: requested capabilities "
+                            f"{escalated} are not held by parent delegation"
+                        )
+                    }
+
             now = int(time.time())
             exp = now + (expiry_hours * 3600)
             jti = secrets.token_urlsafe(16)
@@ -99,11 +141,25 @@ class DelegationService:
                 )
             }
 
-    def verify_delegation(self, token: str) -> dict:
+    def verify_delegation(self, token: str, _seen: Optional[set] = None) -> dict:
         """Verify a UCAN delegation token.
 
-        Checks: signature validity, expiry, revocation, and structure.
+        Checks: signature validity, expiry, revocation, structure, and
+        recursively the validity of every parent token referenced in the
+        `prf` (proof) chain. If any ancestor is invalid (bad signature,
+        expired, revoked, or itself has a bad parent), the whole chain
+        is rejected.
+
+        Args:
+            token: The JWT delegation token to verify.
+            _seen: Internal set of jti values already seen during
+                recursion. Used to detect cycles and prevent infinite
+                recursion on malicious/looped proof chains.
         """
+        # Track jtis seen in this verification run to prevent cycles.
+        if _seen is None:
+            _seen = set()
+
         try:
             # Get server public key for verification
             public_key = did_key_to_public_key(self._server_did)
@@ -122,6 +178,48 @@ class DelegationService:
                 for d in data["delegations"]:
                     if d.get("jti") == jti and d.get("revoked"):
                         return {"valid": False, "reason": "Token has been revoked"}
+
+            # Detect cycles in the proof chain. A well-formed chain is
+            # acyclic, so seeing the same jti twice indicates tampering
+            # or a malicious loop. Bail out rather than recurse forever.
+            if jti and jti in _seen:
+                return {
+                    "valid": False,
+                    "reason": "Cycle detected in delegation proof chain",
+                }
+            if jti:
+                _seen.add(jti)
+
+            # Recursively verify every parent token in the prf chain.
+            # Without this, an attacker could forge a parent_token value
+            # at creation time (if validation is bypassed) or present
+            # this token to downstream consumers who rely on the chain
+            # for authority. Any invalid ancestor invalidates the whole
+            # chain.
+            proof_chain = claims.get("prf", []) or []
+            for parent_token in proof_chain:
+                if not isinstance(parent_token, str) or not parent_token:
+                    return {
+                        "valid": False,
+                        "reason": "Malformed parent token in proof chain",
+                    }
+                parent_result = self.verify_delegation(parent_token, _seen=_seen)
+                if not parent_result.get("valid"):
+                    return {
+                        "valid": False,
+                        "reason": (
+                            "Invalid parent in proof chain: "
+                            f"{parent_result.get('reason', 'unknown reason')}"
+                        ),
+                    }
+                # Also reject if a parent is expired. jwt.decode raises
+                # ExpiredSignatureError by default, but we guard against
+                # any future change that might relax that.
+                if parent_result.get("expired"):
+                    return {
+                        "valid": False,
+                        "reason": "Parent delegation in proof chain has expired",
+                    }
 
             return {
                 "valid": True,

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -92,3 +92,211 @@ class TestListDelegations:
         results = delegation_service.list_delegations()
         for record in results:
             assert "token" not in record
+
+
+class TestDelegationChainSecurity:
+    """Security tests for UCAN delegation chain verification.
+
+    These tests cover the fix for the delegation chain auth bypass,
+    where create_delegation previously embedded an unverified
+    parent_token into the new JWT and verify_delegation never walked
+    the prf chain. The attacker could forge UCAN chains claiming
+    authority from any agent.
+    """
+
+    def test_forged_parent_token_is_rejected(self, delegation_service):
+        """A bogus string passed as parent_token must not produce a new delegation."""
+        result = delegation_service.create_delegation(
+            issuer_agent_id="attestix:issuer",
+            audience_agent_id="attestix:audience",
+            capabilities=["read"],
+            parent_token="this.is.not.a.real.jwt",
+        )
+        assert "error" in result
+        assert "token" not in result
+        assert "parent" in result["error"].lower()
+
+    def test_forged_parent_with_valid_structure_but_bad_signature_is_rejected(
+        self, delegation_service
+    ):
+        """A syntactically valid JWT signed by some other key must be rejected."""
+        import jwt as pyjwt
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+        )
+
+        attacker_key = Ed25519PrivateKey.generate()
+        forged = pyjwt.encode(
+            {
+                "iss": "did:key:attacker",
+                "aud": "attestix:victim",
+                "sub": "attestix:victim",
+                "iat": 1_000_000_000,
+                "exp": 9_999_999_999,
+                "nbf": 1_000_000_000,
+                "jti": "forged-jti",
+                "att": ["admin", "read", "write"],
+                "delegator": "attestix:victim-delegator",
+                "prf": [],
+                "typ": "ucan/delegation",
+            },
+            attacker_key,
+            algorithm="EdDSA",
+        )
+
+        # Attacker tries to create a downstream delegation using the forged parent.
+        result = delegation_service.create_delegation(
+            issuer_agent_id="attestix:attacker",
+            audience_agent_id="attestix:target",
+            capabilities=["admin"],
+            parent_token=forged,
+        )
+        assert "error" in result
+        assert "token" not in result
+
+    def test_capability_escalation_is_blocked(self, delegation_service):
+        """Child capabilities must be a subset of parent capabilities."""
+        parent = delegation_service.create_delegation(
+            issuer_agent_id="attestix:root",
+            audience_agent_id="attestix:middle",
+            capabilities=["read"],
+        )
+        assert "token" in parent
+
+        # Middle tries to escalate to 'write' which the parent never granted.
+        child = delegation_service.create_delegation(
+            issuer_agent_id="attestix:middle",
+            audience_agent_id="attestix:leaf",
+            capabilities=["read", "write"],
+            parent_token=parent["token"],
+        )
+        assert "error" in child
+        assert "token" not in child
+        assert "escal" in child["error"].lower() or "subset" in child["error"].lower() or "not held" in child["error"].lower()
+
+    def test_capability_attenuation_allows_subset(self, delegation_service):
+        """A child may legitimately narrow capabilities vs its parent."""
+        parent = delegation_service.create_delegation(
+            issuer_agent_id="attestix:root",
+            audience_agent_id="attestix:middle",
+            capabilities=["read", "write", "admin"],
+        )
+        child = delegation_service.create_delegation(
+            issuer_agent_id="attestix:middle",
+            audience_agent_id="attestix:leaf",
+            capabilities=["read"],
+            parent_token=parent["token"],
+        )
+        assert "token" in child
+        assert "error" not in child
+
+    def test_expired_parent_is_rejected(self, delegation_service):
+        """A parent whose exp is in the past must not be usable to mint children."""
+        # Create a parent that is already expired by patching time.time
+        # at creation so exp <= now when verify runs later.
+        import time as time_mod
+        from unittest.mock import patch
+
+        # Issue a parent in the far past so it expires immediately.
+        # expiry_hours must be positive, so we shift now backwards.
+        past = int(time_mod.time()) - (48 * 3600)
+        with patch("services.delegation_service.time.time", return_value=past):
+            parent = delegation_service.create_delegation(
+                issuer_agent_id="attestix:root",
+                audience_agent_id="attestix:middle",
+                capabilities=["read"],
+                expiry_hours=1,  # exp = past + 1h, long gone by real now
+            )
+        assert "token" in parent
+
+        # Now, at real current time, the parent's exp is in the past.
+        child = delegation_service.create_delegation(
+            issuer_agent_id="attestix:middle",
+            audience_agent_id="attestix:leaf",
+            capabilities=["read"],
+            parent_token=parent["token"],
+        )
+        assert "error" in child
+        assert "token" not in child
+
+    def test_revoked_parent_is_rejected(self, delegation_service):
+        """A revoked parent must not be usable to mint children."""
+        parent = delegation_service.create_delegation(
+            issuer_agent_id="attestix:root",
+            audience_agent_id="attestix:middle",
+            capabilities=["read", "write"],
+        )
+        assert "token" in parent
+        parent_jti = parent["delegation"]["jti"]
+
+        revoke_result = delegation_service.revoke_delegation(
+            parent_jti, reason="security incident"
+        )
+        assert revoke_result.get("revoked") is True
+
+        child = delegation_service.create_delegation(
+            issuer_agent_id="attestix:middle",
+            audience_agent_id="attestix:leaf",
+            capabilities=["read"],
+            parent_token=parent["token"],
+        )
+        assert "error" in child
+        assert "token" not in child
+        assert "revoke" in child["error"].lower() or "parent" in child["error"].lower()
+
+    def test_valid_chain_passes(self, delegation_service):
+        """A well-formed grandparent -> parent -> child chain verifies end-to-end."""
+        grandparent = delegation_service.create_delegation(
+            issuer_agent_id="attestix:root",
+            audience_agent_id="attestix:middle",
+            capabilities=["read", "write", "admin"],
+        )
+        assert "token" in grandparent
+
+        parent = delegation_service.create_delegation(
+            issuer_agent_id="attestix:middle",
+            audience_agent_id="attestix:sub",
+            capabilities=["read", "write"],
+            parent_token=grandparent["token"],
+        )
+        assert "token" in parent
+
+        child = delegation_service.create_delegation(
+            issuer_agent_id="attestix:sub",
+            audience_agent_id="attestix:leaf",
+            capabilities=["read"],
+            parent_token=parent["token"],
+        )
+        assert "token" in child
+        assert "error" not in child
+
+        # verify_delegation must walk the prf chain successfully.
+        verified = delegation_service.verify_delegation(child["token"])
+        assert verified["valid"] is True
+        assert verified["capabilities"] == ["read"]
+        assert verified["proof_chain"] == [parent["token"]]
+
+    def test_verify_walks_chain_and_rejects_when_ancestor_revoked(
+        self, delegation_service
+    ):
+        """verify_delegation must fail if any ancestor in prf is revoked,
+        even if the leaf token itself is otherwise valid."""
+        grandparent = delegation_service.create_delegation(
+            issuer_agent_id="attestix:root",
+            audience_agent_id="attestix:middle",
+            capabilities=["read", "write"],
+        )
+        parent = delegation_service.create_delegation(
+            issuer_agent_id="attestix:middle",
+            audience_agent_id="attestix:sub",
+            capabilities=["read"],
+            parent_token=grandparent["token"],
+        )
+        # Grandparent revoked AFTER the chain was built.
+        delegation_service.revoke_delegation(
+            grandparent["delegation"]["jti"], reason="key compromised"
+        )
+
+        result = delegation_service.verify_delegation(parent["token"])
+        assert result["valid"] is False
+        assert "parent" in result["reason"].lower() or "revoke" in result["reason"].lower()


### PR DESCRIPTION
## Summary

Closes a CRITICAL authentication bypass in `services/delegation_service.py`.

- `create_delegation` previously accepted an arbitrary `parent_token` string and embedded it verbatim in the new JWT's `prf` field without any check. `verify_delegation` only validated the leaf signature and never walked `prf`. Together, an attacker could forge UCAN chains claiming authority from any agent and escalate capabilities beyond what any legitimate parent granted.
- `create_delegation` now verifies the `parent_token` fully (signature, expiry, revocation, and its own `prf` chain) and enforces UCAN capability attenuation: child `att` must be a subset of parent `att`.
- `verify_delegation` now recursively verifies every ancestor in the `prf` chain. Any invalid ancestor invalidates the whole chain. A `jti`-based cycle guard prevents infinite recursion on malicious looped chains.

## Test plan

- [x] New `TestDelegationChainSecurity` covers: forged string parent rejected, foreign-key-signed JWT rejected, capability escalation blocked, legitimate subset attenuation allowed, expired parent rejected, revoked parent rejected, valid 3-deep chain passes, ancestor revocation invalidates downstream verify.
- [x] All 17 delegation tests pass (`python -m pytest tests/unit/test_delegation.py`).
- [x] Full suite passes: 323 passed, 0 failed (`python -m pytest`).
- [x] No public API shape change; legitimate callers unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delegation chain validation now rejects capability escalation attempts
  * Parent token verification improved to detect and reject invalid, expired, or revoked tokens
  * Added cycle detection to delegation proof chains

* **Tests**
  * Added comprehensive delegation chain security test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->