### PR TITLE
fix: Article 43 differentiates Annex III categories per EU AI Act (#40)

### DIFF
--- a/api/routers/compliance.py
+++ b/api/routers/compliance.py
@@ -28,6 +28,23 @@ class CreateComplianceProfileRequest(BaseModel):
     human_oversight_measures: str = Field("", description="Human oversight measures (required for high-risk)")
     provider_address: str = Field("", description="Provider address")
     authorised_representative: str = Field("", description="EU authorised representative (if applicable)")
+    annex_iii_category: Optional[int] = Field(
+        None,
+        description=(
+            "Annex III point (1-8) for high-risk systems. Point 1 (biometrics) "
+            "mandates third-party assessment per Article 43; Points 2-8 permit "
+            "self-assessment via Annex VI internal control."
+        ),
+    )
+    annex_iii_exception: Optional[str] = Field(
+        None,
+        description=(
+            "Carve-out within Points 2-8 that still requires third-party "
+            "assessment. Valid values: "
+            "'biometric_identification_law_enforcement', "
+            "'financial_fraud_detection', 'political_campaign_organization'."
+        ),
+    )
 
 
 class RecordAssessmentRequest(BaseModel):
@@ -62,6 +79,8 @@ def create_compliance_profile(
         human_oversight_measures=body.human_oversight_measures,
         provider_address=body.provider_address,
         authorised_representative=body.authorised_representative,
+        annex_iii_category=body.annex_iii_category,
+        annex_iii_exception=body.annex_iii_exception,
     )
     if isinstance(result, dict) and "error" in result:
         if "not found" in result["error"].lower():

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -72,7 +72,13 @@ See the [Risk Classification Guide](risk-classification.md). In short:
 
 ### Can high-risk systems use self-assessment?
 
-Attestix currently requires third-party assessment for all high-risk systems. If you attempt `record_conformity_assessment` with `assessment_type="self"` on a high-risk agent, it will return an error. This is more conservative than the Act requires (which allows self-assessment for some Annex III categories) but errs on the side of compliance safety.
+It depends on the Annex III category, per EU AI Act Article 43. Set the `annex_iii_category` field on the compliance profile (1 through 8):
+
+- **Point 1 (biometrics):** third-party assessment required (Annex VII procedure). Self-assessment is blocked.
+- **Points 2-8:** self-assessment via internal control is permitted (Annex VI procedure).
+- **Unspecified category:** Attestix fails safe and blocks self-assessment until you declare the Annex III point.
+
+Three documented carve-outs within Points 2-8 still require third-party assessment even if you set the Annex III point: biometric identification for law enforcement, financial fraud detection, and political campaign organization. Set `annex_iii_exception` to the appropriate flag to force third-party.
 
 ### What is an Annex V declaration?
 

--- a/services/compliance_service.py
+++ b/services/compliance_service.py
@@ -17,6 +17,39 @@ VALID_RISK_CATEGORIES = {"minimal", "limited", "high", "unacceptable"}
 VALID_ASSESSMENT_TYPES = {"self", "third_party"}
 VALID_ASSESSMENT_RESULTS = {"pass", "conditional", "fail"}
 
+# EU AI Act Annex III high-risk category points (1 through 8).
+# Per Article 43, different conformity assessment procedures apply based on
+# which Annex III point the system falls under.
+VALID_ANNEX_III_CATEGORIES = {1, 2, 3, 4, 5, 6, 7, 8}
+
+# Human-readable descriptions of each Annex III point (Regulation (EU) 2024/1689).
+ANNEX_III_DESCRIPTIONS = {
+    1: "Biometrics (remote identification, categorisation, emotion recognition)",
+    2: "Critical infrastructure (management and operation)",
+    3: "Education and vocational training (access, evaluation, assessment)",
+    4: "Employment, workers management, access to self-employment",
+    5: "Access to essential private and public services and benefits",
+    6: "Law enforcement",
+    7: "Migration, asylum and border control management",
+    8: "Administration of justice and democratic processes",
+}
+
+# Exception flags (within Points 2-8) that still mandate third-party assessment
+# per Article 43. These are documented carve-outs in the Act where internal
+# control (Annex VI) is NOT sufficient and notified body assessment (Annex VII)
+# is required regardless of the headline Annex III point.
+VALID_ANNEX_III_EXCEPTIONS = {
+    # Biometric identification used by or on behalf of law enforcement
+    # (Annex III Point 6 sub-use of biometrics).
+    "biometric_identification_law_enforcement",
+    # Detection of financial fraud affecting access to essential services
+    # (Annex III Point 5 sub-use).
+    "financial_fraud_detection",
+    # Political campaign organization / influencing voter behaviour
+    # (Annex III Point 8 sub-use).
+    "political_campaign_organization",
+}
+
 # EU AI Act Annex V required fields for declaration of conformity
 ANNEX_V_REQUIRED = [
     "provider_name",
@@ -24,6 +57,68 @@ ANNEX_V_REQUIRED = [
     "risk_category",
     "conformity_assessment",
 ]
+
+
+def _requires_third_party_assessment(
+    annex_iii_category: Optional[int],
+    annex_iii_exception: Optional[str],
+) -> tuple:
+    """Determine whether a high-risk system requires third-party assessment.
+
+    Per EU AI Act Article 43:
+      - Annex III Point 1 (biometrics): third-party (Annex VII) required.
+      - Annex III Points 2 to 8: self-assessment via internal control (Annex VI)
+        is permitted, EXCEPT for three documented carve-outs (biometric
+        identification for law enforcement, financial fraud detection, and
+        political campaign organization) which still require Annex VII.
+      - Unspecified Annex III category: default to requiring third-party
+        (fail-safe).
+
+    Returns a tuple of (required: bool, reason: str). `reason` is a human
+    readable explanation referencing the specific Annex III point.
+    """
+    if annex_iii_exception is not None:
+        if annex_iii_exception not in VALID_ANNEX_III_EXCEPTIONS:
+            # Unknown exception flag - fail safe.
+            return (
+                True,
+                "Unknown Annex III exception flag; defaulting to third-party "
+                "assessment (Article 43, fail-safe).",
+            )
+        return (
+            True,
+            f"Annex III exception '{annex_iii_exception}' requires third-party "
+            f"conformity assessment per Article 43 (Annex VII procedure).",
+        )
+
+    if annex_iii_category is None:
+        return (
+            True,
+            "Annex III category not specified for high-risk system; defaulting "
+            "to third-party assessment per Article 43 (fail-safe).",
+        )
+
+    if annex_iii_category == 1:
+        return (
+            True,
+            "Annex III Point 1 (biometrics) requires third-party conformity "
+            "assessment via notified body per Article 43 (Annex VII procedure).",
+        )
+
+    if annex_iii_category in {2, 3, 4, 5, 6, 7, 8}:
+        return (
+            False,
+            f"Annex III Point {annex_iii_category} "
+            f"({ANNEX_III_DESCRIPTIONS[annex_iii_category]}) permits "
+            f"self-assessment via internal control per Article 43 "
+            f"(Annex VI procedure).",
+        )
+
+    return (
+        True,
+        f"Invalid Annex III category {annex_iii_category}; defaulting to "
+        f"third-party assessment per Article 43 (fail-safe).",
+    )
 
 
 class ComplianceService:
@@ -62,8 +157,24 @@ class ComplianceService:
         human_oversight_measures: str = "",
         provider_address: str = "",
         authorised_representative: str = "",
+        annex_iii_category: Optional[int] = None,
+        annex_iii_exception: Optional[str] = None,
     ) -> dict:
-        """Create an EU AI Act compliance profile for an agent."""
+        """Create an EU AI Act compliance profile for an agent.
+
+        Args:
+            annex_iii_category: For high-risk systems, the Annex III point
+                (1 through 8) the system falls under. Point 1 covers biometrics
+                and mandates third-party assessment; Points 2-8 permit
+                self-assessment via internal control (Annex VI). Optional for
+                non-high-risk systems; if omitted for a high-risk system the
+                service defaults to requiring third-party assessment.
+            annex_iii_exception: For high-risk systems in Points 2-8, a flag
+                indicating the system falls into one of the documented
+                carve-outs that still require third-party assessment. Valid
+                values: 'biometric_identification_law_enforcement',
+                'financial_fraud_detection', 'political_campaign_organization'.
+        """
         try:
             if risk_category not in VALID_RISK_CATEGORIES:
                 return {
@@ -76,6 +187,23 @@ class ComplianceService:
                     "error": "Unacceptable-risk AI systems are prohibited under the EU AI Act "
                     "(Article 5). Cannot create a compliance profile for prohibited systems."
                 }
+
+            # Validate Annex III category if provided
+            if annex_iii_category is not None:
+                if annex_iii_category not in VALID_ANNEX_III_CATEGORIES:
+                    return {
+                        "error": f"Invalid annex_iii_category '{annex_iii_category}'. "
+                        f"Must be one of: {sorted(VALID_ANNEX_III_CATEGORIES)} "
+                        f"(see EU AI Act Annex III)."
+                    }
+
+            # Validate Annex III exception flag if provided
+            if annex_iii_exception is not None:
+                if annex_iii_exception not in VALID_ANNEX_III_EXCEPTIONS:
+                    return {
+                        "error": f"Invalid annex_iii_exception '{annex_iii_exception}'. "
+                        f"Must be one of: {sorted(VALID_ANNEX_III_EXCEPTIONS)}."
+                    }
 
             # Verify agent exists
             agent = self.identity_svc.get_identity(agent_id)
@@ -98,6 +226,8 @@ class ComplianceService:
                 "profile_id": profile_id,
                 "agent_id": agent_id,
                 "risk_category": risk_category,
+                "annex_iii_category": annex_iii_category,
+                "annex_iii_exception": annex_iii_exception,
                 "provider": {
                     "name": provider_name,
                     "did": self._server_did,
@@ -212,11 +342,21 @@ class ComplianceService:
             if not profile:
                 return {"error": f"No compliance profile found for {agent_id}. Create one first."}
 
-            # High-risk systems require third-party assessment
+            # Article 43 differentiation: third-party is only required for
+            # specific Annex III categories/exceptions, not all high-risk.
             if profile["risk_category"] == "high" and assessment_type == "self":
-                return {
-                    "error": "High-risk AI systems require third_party conformity assessment (Article 43)."
-                }
+                annex_cat = profile.get("annex_iii_category")
+                annex_exc = profile.get("annex_iii_exception")
+                required, reason = _requires_third_party_assessment(
+                    annex_cat, annex_exc
+                )
+                if required:
+                    return {
+                        "error": (
+                            f"Self-assessment not permitted: {reason} Use "
+                            f"assessment_type='third_party' with a notified body."
+                        )
+                    }
 
             assessment_id = f"assess:{uuid.uuid4().hex[:12]}"
             now = datetime.now(timezone.utc).isoformat()
@@ -281,7 +421,9 @@ class ComplianceService:
             if profile["risk_category"] == "high":
                 if not profile["transparency"].get("human_oversight_measures", "").strip():
                     missing_fields.append("human_oversight_measures")
-                # Re-validate: high-risk requires third-party assessment
+                # Re-validate Article 43: third-party assessment requirement is
+                # tied to specific Annex III categories / exceptions, not all
+                # high-risk systems.
                 data_check = load_compliance()
                 assess_id = profile["conformity"]["assessment_id"]
                 if assess_id:
@@ -290,10 +432,17 @@ class ComplianceService:
                         None
                     )
                     if assessment and assessment.get("assessment_type") != "third_party":
-                        return {
-                            "error": "High-risk AI systems require third_party conformity assessment (Article 43). "
-                            "Current assessment is self-assessment."
-                        }
+                        required, reason = _requires_third_party_assessment(
+                            profile.get("annex_iii_category"),
+                            profile.get("annex_iii_exception"),
+                        )
+                        if required:
+                            return {
+                                "error": (
+                                    f"Cannot issue declaration: {reason} "
+                                    f"Current assessment is self-assessment."
+                                )
+                            }
             if missing_fields:
                 return {
                     "error": f"Cannot generate declaration: missing required fields: {', '.join(missing_fields)}. "
@@ -335,6 +484,8 @@ class ComplianceService:
                     "4_intended_purpose": profile["ai_system"]["intended_purpose"],
                     # 5. Risk classification
                     "5_risk_category": profile["risk_category"],
+                    "5a_annex_iii_category": profile.get("annex_iii_category"),
+                    "5b_annex_iii_exception": profile.get("annex_iii_exception"),
                     # 6. Conformity assessment procedure
                     "6_conformity_assessment_id": profile["conformity"]["assessment_id"],
                     "6a_assessment_type": (

--- a/tests/unit/test_compliance.py
+++ b/tests/unit/test_compliance.py
@@ -69,6 +69,7 @@ class TestConformityAssessment:
         assert result["result"] == "pass"
 
     def test_high_risk_requires_third_party(self, compliance_service, sample_agent_id):
+        """Unspecified Annex III category should fail-safe to requiring third-party."""
         compliance_service.create_compliance_profile(
             sample_agent_id, "high", "Corp",
             intended_purpose="High-risk AI",
@@ -82,6 +83,230 @@ class TestConformityAssessment:
         )
         assert "error" in result
         assert "third_party" in result["error"]
+
+
+class TestArticle43AnnexIIIDifferentiation:
+    """Article 43 differentiates Annex III categories for conformity assessment.
+
+    Point 1 (biometrics) requires third-party via Annex VII. Points 2-8 permit
+    self-assessment via Annex VI internal control, except for three carve-outs.
+    """
+
+    def test_annex_iii_point_1_biometrics_blocks_self_assessment(
+        self, compliance_service, sample_agent_id
+    ):
+        """Point 1 (biometrics) must use third-party / notified body assessment."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "BiometricCorp",
+            intended_purpose="Remote biometric identification in public spaces",
+            human_oversight_measures="Human review",
+            annex_iii_category=1,
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="self",
+            assessor_name="Internal QA",
+            result="pass",
+        )
+        assert "error" in result
+        assert "Annex III Point 1" in result["error"]
+        assert "third_party" in result["error"].lower() or "third-party" in result["error"].lower()
+
+    def test_annex_iii_point_1_biometrics_allows_third_party(
+        self, compliance_service, sample_agent_id
+    ):
+        """Point 1 (biometrics) accepts third-party assessment."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "BiometricCorp",
+            intended_purpose="Remote biometric identification in public spaces",
+            human_oversight_measures="Human review",
+            annex_iii_category=1,
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="third_party",
+            assessor_name="TUV SUD (Notified Body)",
+            result="pass",
+            ce_marking_eligible=True,
+        )
+        assert "assessment_id" in result
+        assert result["result"] == "pass"
+
+    def test_annex_iii_point_2_critical_infrastructure_allows_self_assessment(
+        self, compliance_service, sample_agent_id
+    ):
+        """Point 2 (critical infrastructure) permits Annex VI internal control."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "GridCorp",
+            intended_purpose="Management of electricity grid operations",
+            human_oversight_measures="SCADA operator supervision",
+            annex_iii_category=2,
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="self",
+            assessor_name="Internal QA",
+            result="pass",
+        )
+        assert "assessment_id" in result, f"Self-assessment should be allowed for Point 2: {result}"
+        assert result["result"] == "pass"
+
+    def test_annex_iii_point_3_education_allows_self_assessment(
+        self, compliance_service, sample_agent_id
+    ):
+        """Point 3 (education) permits Annex VI internal control."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "EduCorp",
+            intended_purpose="Student exam scoring and evaluation",
+            human_oversight_measures="Teacher review of flagged cases",
+            annex_iii_category=3,
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="self",
+            assessor_name="Internal QA",
+            result="pass",
+        )
+        assert "assessment_id" in result, f"Self-assessment should be allowed for Point 3: {result}"
+        assert result["result"] == "pass"
+
+    def test_annex_iii_point_4_employment_allows_self_assessment(
+        self, compliance_service, sample_agent_id
+    ):
+        """Point 4 (employment) permits Annex VI internal control."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "HRCorp",
+            intended_purpose="Candidate screening and ranking",
+            human_oversight_measures="HR review of final decisions",
+            annex_iii_category=4,
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="self",
+            assessor_name="Internal QA",
+            result="pass",
+        )
+        assert "assessment_id" in result
+
+    def test_unspecified_annex_iii_category_blocks_self_assessment(
+        self, compliance_service, sample_agent_id
+    ):
+        """Fail-safe: unspecified Annex III category defaults to third-party."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "UnknownCorp",
+            intended_purpose="Unspecified high-risk AI",
+            human_oversight_measures="Human review",
+            # annex_iii_category intentionally omitted
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="self",
+            assessor_name="Internal QA",
+            result="pass",
+        )
+        assert "error" in result
+        assert "not specified" in result["error"].lower() or "fail-safe" in result["error"].lower()
+
+    def test_exception_biometric_law_enforcement_blocks_self_assessment(
+        self, compliance_service, sample_agent_id
+    ):
+        """Exception: biometric identification for law enforcement still requires third-party."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "LawEnforceCorp",
+            intended_purpose="Biometric identification for law enforcement investigations",
+            human_oversight_measures="Officer review",
+            annex_iii_category=6,
+            annex_iii_exception="biometric_identification_law_enforcement",
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="self",
+            assessor_name="Internal QA",
+            result="pass",
+        )
+        assert "error" in result
+        assert "biometric_identification_law_enforcement" in result["error"]
+
+    def test_exception_financial_fraud_blocks_self_assessment(
+        self, compliance_service, sample_agent_id
+    ):
+        """Exception: financial fraud detection still requires third-party."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "BankCorp",
+            intended_purpose="Detection of financial fraud affecting account access",
+            human_oversight_measures="Fraud analyst review",
+            annex_iii_category=5,
+            annex_iii_exception="financial_fraud_detection",
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="self",
+            assessor_name="Internal QA",
+            result="pass",
+        )
+        assert "error" in result
+        assert "financial_fraud_detection" in result["error"]
+
+    def test_exception_political_campaign_blocks_self_assessment(
+        self, compliance_service, sample_agent_id
+    ):
+        """Exception: political campaign organization still requires third-party."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "PolitechCorp",
+            intended_purpose="Voter outreach and campaign message personalization",
+            human_oversight_measures="Campaign manager review",
+            annex_iii_category=8,
+            annex_iii_exception="political_campaign_organization",
+        )
+        result = compliance_service.record_conformity_assessment(
+            agent_id=sample_agent_id,
+            assessment_type="self",
+            assessor_name="Internal QA",
+            result="pass",
+        )
+        assert "error" in result
+        assert "political_campaign_organization" in result["error"]
+
+    def test_invalid_annex_iii_category_rejected(
+        self, compliance_service, sample_agent_id
+    ):
+        """Profile creation should reject invalid Annex III values."""
+        result = compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "Corp",
+            intended_purpose="Test",
+            human_oversight_measures="Human review",
+            annex_iii_category=9,
+        )
+        assert "error" in result
+        assert "annex_iii_category" in result["error"].lower() or "annex iii" in result["error"].lower()
+
+    def test_invalid_annex_iii_exception_rejected(
+        self, compliance_service, sample_agent_id
+    ):
+        """Profile creation should reject unknown exception flags."""
+        result = compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "Corp",
+            intended_purpose="Test",
+            human_oversight_measures="Human review",
+            annex_iii_category=5,
+            annex_iii_exception="bogus_flag",
+        )
+        assert "error" in result
+        assert "annex_iii_exception" in result["error"].lower()
+
+    def test_profile_persists_annex_iii_fields(
+        self, compliance_service, sample_agent_id
+    ):
+        """Profile should store annex_iii_category and annex_iii_exception."""
+        compliance_service.create_compliance_profile(
+            sample_agent_id, "high", "Corp",
+            intended_purpose="Test",
+            human_oversight_measures="Human review",
+            annex_iii_category=3,
+        )
+        profile = compliance_service.get_compliance_profile(sample_agent_id)
+        assert profile["annex_iii_category"] == 3
+        assert profile["annex_iii_exception"] is None
 
 
 class TestDeclarationOfConformity:

--- a/tools/compliance_tools.py
+++ b/tools/compliance_tools.py
@@ -26,6 +26,8 @@ def register(mcp):
         human_oversight_measures: str = "",
         provider_address: str = "",
         authorised_representative: str = "",
+        annex_iii_category: int = 0,
+        annex_iii_exception: str = "",
     ) -> str:
         """Create an EU AI Act compliance profile for an agent.
 
@@ -40,6 +42,15 @@ def register(mcp):
             human_oversight_measures: Human oversight mechanisms in place (required for high-risk).
             provider_address: Registered address of the provider.
             authorised_representative: Name of the EU authorised representative (if provider is outside EU).
+            annex_iii_category: For high-risk systems, the Annex III point 1-8.
+                Point 1 (biometrics) requires third-party assessment; Points 2-8
+                permit self-assessment via Annex VI internal control. Use 0 or
+                omit to leave unspecified (defaults to requiring third-party).
+            annex_iii_exception: For Points 2-8, one of the documented carve-outs
+                that still require third-party assessment per Article 43:
+                'biometric_identification_law_enforcement',
+                'financial_fraud_detection', 'political_campaign_organization'.
+                Leave empty if no exception applies.
         """
         err = _validate_required({"agent_id": agent_id, "risk_category": risk_category,
                                    "provider_name": provider_name})
@@ -59,6 +70,8 @@ def register(mcp):
             human_oversight_measures=human_oversight_measures,
             provider_address=provider_address,
             authorised_representative=authorised_representative,
+            annex_iii_category=annex_iii_category if annex_iii_category else None,
+            annex_iii_exception=annex_iii_exception or None,
         )
         return json.dumps(result, indent=2, default=str)
 

--- a/website/content/docs/reference/faq.mdx
+++ b/website/content/docs/reference/faq.mdx
@@ -77,7 +77,13 @@ See the [Risk Classification Guide](/docs/guides/risk-classification). In short:
 
 ### Can high-risk systems use self-assessment?
 
-Attestix currently requires third-party assessment for all high-risk systems. If you attempt `record_conformity_assessment` with `assessment_type="self"` on a high-risk agent, it will return an error. This is more conservative than the Act requires (which allows self-assessment for some Annex III categories) but errs on the side of compliance safety.
+It depends on the Annex III category, per EU AI Act Article 43. Set the `annex_iii_category` field on the compliance profile (1 through 8):
+
+- **Point 1 (biometrics):** third-party assessment required (Annex VII procedure). Self-assessment is blocked.
+- **Points 2-8:** self-assessment via internal control is permitted (Annex VI procedure).
+- **Unspecified category:** Attestix fails safe and blocks self-assessment until you declare the Annex III point.
+
+Three documented carve-outs within Points 2-8 still require third-party assessment even if you set the Annex III point: biometric identification for law enforcement, financial fraud detection, and political campaign organization. Set `annex_iii_exception` to the appropriate flag to force third-party.
 
 ### What is an Annex V declaration?
 


### PR DESCRIPTION
## Summary

- Replaces the blanket block on self-assessment for high-risk AI systems with proper Article 43 differentiation across Annex III points.
- Adds `annex_iii_category` (1-8) and `annex_iii_exception` fields to compliance profiles, routes conformity assessment through Annex VI vs Annex VII based on those values, and fails safe when the category is unspecified.
- Updates MCP tool, REST API schema, Annex V declaration payload, FAQ docs (MkDocs + Fumadocs), and adds 11 focused unit tests.

## EU AI Act behaviour summary

- Annex III Point 1 (biometrics): self-assessment blocked, third-party (Annex VII) required.
- Annex III Points 2-8: self-assessment via Annex VI internal control allowed.
- Exceptions within Points 2-8 (biometric identification for law enforcement, financial fraud detection, political campaign organization): third-party still required.
- Category unspecified: fail-safe blocks self-assessment and prompts the provider to declare the point.

Error messages now reference the specific Annex III point and procedure so providers can tell exactly why a self-assessment was rejected.

## Test plan

- [x] `python -m pytest` - full suite passes (335 tests total: 244 functional + 91 conformance benchmarks).
- [x] `python -m pytest tests/unit/test_compliance.py -v` - 22 unit tests including 11 new `TestArticle43AnnexIIIDifferentiation` cases.
- [x] New tests cover Point 1 blocked, Points 2/3/4 allowed, three exception carve-outs blocked, unspecified-category fail-safe blocked, invalid category/exception rejection, and profile persistence.
- [x] Existing `test_high_risk_requires_third_party` tests continue to pass because they omit `annex_iii_category` and fall into the fail-safe path.

## References

- EU AI Act Article 43 (conformity assessment procedures)
- Annex III (high-risk AI system classification)
- Annex VI (internal control procedure)
- Annex VII (notified body assessment procedure)

Fixes #40