### PR TITLE
security: batch fixes - SSRF redirect, API key timing, exception leaks, display_name validation, key perms

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,6 +6,7 @@ EU AI Act compliance, reputation, provenance, delegation, DIDs,
 agent cards, and blockchain anchoring.
 """
 
+import hmac
 import os
 import time
 import logging
@@ -112,7 +113,9 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 content={"error": "Missing API key. Provide X-API-Key header or Authorization: Bearer <key>"},
             )
 
-        if provided_key != api_key:
+        # Constant-time comparison to prevent byte-by-byte timing attacks
+        # that could reveal the configured API key.
+        if not hmac.compare_digest(provided_key, api_key):
             return JSONResponse(
                 status_code=403,
                 content={"error": "Invalid API key"},

--- a/api/routers/agent_cards.py
+++ b/api/routers/agent_cards.py
@@ -4,6 +4,7 @@ Discover, parse, and generate Google A2A Agent Cards
 (the /.well-known/agent.json standard).
 """
 
+import logging
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -11,6 +12,8 @@ from pydantic import BaseModel, Field
 
 from api.deps import get_agent_card_service
 from services.agent_card_service import AgentCardService
+
+logger = logging.getLogger("attestix.api.agent_cards")
 
 router = APIRouter(prefix="/v1/agent-cards", tags=["agent-cards"])
 
@@ -61,11 +64,13 @@ def discover_agent(
     """
     result = svc.discover_agent(body.base_url)
     if isinstance(result, dict) and "error" in result:
-        if "timeout" in result["error"].lower():
-            raise HTTPException(status_code=504, detail=result["error"])
-        if "http" in result["error"].lower() and any(c.isdigit() for c in result["error"]):
-            raise HTTPException(status_code=502, detail=result["error"])
-        raise HTTPException(status_code=400, detail=result["error"])
+        error_msg = result["error"]
+        logger.warning("Agent discovery failed for %s: %s", body.base_url, error_msg)
+        if "timeout" in error_msg.lower():
+            raise HTTPException(status_code=504, detail="Agent discovery timed out")
+        if "http" in error_msg.lower() and any(c.isdigit() for c in error_msg):
+            raise HTTPException(status_code=502, detail="Upstream agent discovery error")
+        raise HTTPException(status_code=400, detail="Agent discovery failed")
     return result
 
 
@@ -80,7 +85,8 @@ def parse_agent_card(
     """
     result = svc.parse_agent_card(body.card)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Agent card parsing failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Agent card parsing failed")
     return result
 
 
@@ -105,5 +111,6 @@ def generate_agent_card(
         version=body.version,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Agent card generation failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Agent card generation failed")
     return result

--- a/api/routers/blockchain.py
+++ b/api/routers/blockchain.py
@@ -4,6 +4,7 @@ Anchors cryptographic hashes of off-chain artifacts (UAITs, VCs, audit log
 batches) to Base L2 via Ethereum Attestation Service (EAS).
 """
 
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -13,6 +14,8 @@ from api.deps import get_blockchain_service, get_identity_service, get_credentia
 from services.blockchain_service import BlockchainService
 from services.identity_service import IdentityService
 from services.credential_service import CredentialService
+
+logger = logging.getLogger("attestix.api.blockchain")
 
 router = APIRouter(prefix="/v1/blockchain", tags=["blockchain"])
 
@@ -64,7 +67,8 @@ def anchor_identity(
         artifact_id=body.agent_id,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Identity anchor failed for %s: %s", body.agent_id, result["error"])
+        raise HTTPException(status_code=400, detail="Identity anchoring failed")
     return result
 
 
@@ -89,7 +93,11 @@ def anchor_credential(
         artifact_id=body.credential_id,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning(
+            "Credential anchor failed for %s: %s",
+            body.credential_id, result["error"],
+        )
+        raise HTTPException(status_code=400, detail="Credential anchoring failed")
     return result
 
 
@@ -105,7 +113,11 @@ def anchor_audit_batch(
         end_date=body.end_date,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning(
+            "Audit batch anchor failed for %s: %s",
+            body.agent_id, result["error"],
+        )
+        raise HTTPException(status_code=400, detail="Audit batch anchoring failed")
     return result
 
 
@@ -121,7 +133,8 @@ def verify_anchor(
     """
     result = bc_svc.verify_anchor(body.artifact_hash)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Anchor verification failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Anchor verification failed")
     return result
 
 
@@ -136,7 +149,8 @@ def get_anchor_status(
     """
     result = bc_svc.get_anchor_status(anchor_id)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=500, detail=result["error"])
+        logger.error("Anchor status lookup failed for %s: %s", anchor_id, result["error"])
+        raise HTTPException(status_code=500, detail="Anchor status lookup failed")
     return result
 
 
@@ -148,5 +162,6 @@ def estimate_anchor_cost(
     """Estimate gas cost for an anchoring transaction."""
     result = bc_svc.estimate_anchor_cost(artifact_type=artifact_type)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Anchor cost estimation failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Anchor cost estimation failed")
     return result

--- a/api/routers/compliance.py
+++ b/api/routers/compliance.py
@@ -4,6 +4,7 @@ EU AI Act compliance profiles, conformity assessments (Article 43),
 and declarations of conformity (Annex V).
 """
 
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -11,6 +12,8 @@ from pydantic import BaseModel, Field
 
 from api.deps import get_compliance_service
 from services.compliance_service import ComplianceService
+
+logger = logging.getLogger("attestix.api.compliance")
 
 router = APIRouter(prefix="/v1/compliance", tags=["compliance"])
 
@@ -64,9 +67,11 @@ def create_compliance_profile(
         authorised_representative=body.authorised_representative,
     )
     if isinstance(result, dict) and "error" in result:
-        if "not found" in result["error"].lower():
-            raise HTTPException(status_code=404, detail=result["error"])
-        raise HTTPException(status_code=400, detail=result["error"])
+        error_msg = result["error"]
+        logger.warning("Compliance profile creation failed: %s", error_msg)
+        if "not found" in error_msg.lower():
+            raise HTTPException(status_code=404, detail="Agent not found")
+        raise HTTPException(status_code=400, detail="Compliance profile creation failed")
     return result
 
 
@@ -84,7 +89,8 @@ def list_compliance_profiles(
         limit=limit,
     )
     if results and isinstance(results[0], dict) and "error" in results[0]:
-        raise HTTPException(status_code=500, detail=results[0]["error"])
+        logger.error("Compliance profile listing failed: %s", results[0]["error"])
+        raise HTTPException(status_code=500, detail="Compliance profile listing failed")
     return results
 
 
@@ -114,9 +120,11 @@ def get_compliance_status(
     """
     result = svc.get_compliance_status(profile_id)
     if isinstance(result, dict) and "error" in result:
-        if "not found" in result["error"].lower():
-            raise HTTPException(status_code=404, detail=result["error"])
-        raise HTTPException(status_code=400, detail=result["error"])
+        error_msg = result["error"]
+        logger.warning("Compliance status check failed for %s: %s", profile_id, error_msg)
+        if "not found" in error_msg.lower():
+            raise HTTPException(status_code=404, detail="Compliance profile not found")
+        raise HTTPException(status_code=400, detail="Compliance status check failed")
     return result
 
 
@@ -135,9 +143,11 @@ def record_conformity_assessment(
         ce_marking_eligible=body.ce_marking_eligible,
     )
     if isinstance(result, dict) and "error" in result:
-        if "not found" in result["error"].lower():
-            raise HTTPException(status_code=404, detail=result["error"])
-        raise HTTPException(status_code=400, detail=result["error"])
+        error_msg = result["error"]
+        logger.warning("Conformity assessment failed: %s", error_msg)
+        if "not found" in error_msg.lower():
+            raise HTTPException(status_code=404, detail="Compliance profile not found")
+        raise HTTPException(status_code=400, detail="Conformity assessment failed")
     return result
 
 
@@ -149,7 +159,12 @@ def generate_declaration_of_conformity(
     """Generate an EU AI Act Annex V declaration of conformity."""
     result = svc.generate_declaration_of_conformity(body.agent_id)
     if isinstance(result, dict) and "error" in result:
-        if "not found" in result["error"].lower():
-            raise HTTPException(status_code=404, detail=result["error"])
-        raise HTTPException(status_code=400, detail=result["error"])
+        error_msg = result["error"]
+        logger.warning(
+            "Declaration generation failed for %s: %s",
+            body.agent_id, error_msg,
+        )
+        if "not found" in error_msg.lower():
+            raise HTTPException(status_code=404, detail="Compliance profile not found")
+        raise HTTPException(status_code=400, detail="Declaration generation failed")
     return result

--- a/api/routers/credentials.py
+++ b/api/routers/credentials.py
@@ -4,6 +4,7 @@ Issues, verifies, and manages W3C Verifiable Credentials (VC Data Model 1.1)
 with Ed25519Signature2020 proofs.
 """
 
+import logging
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -11,6 +12,8 @@ from pydantic import BaseModel, Field
 
 from api.deps import get_credential_service
 from services.credential_service import CredentialService
+
+logger = logging.getLogger("attestix.api.credentials")
 
 router = APIRouter(prefix="/v1", tags=["credentials"])
 
@@ -60,7 +63,8 @@ def issue_credential(
         expiry_days=body.expiry_days,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Credential issuance failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Credential issuance failed")
     return result
 
 
@@ -81,7 +85,8 @@ def list_credentials(
     )
     # Service returns list with error dict on failure
     if results and isinstance(results[0], dict) and "error" in results[0]:
-        raise HTTPException(status_code=500, detail=results[0]["error"])
+        logger.error("Credential listing failed: %s", results[0]["error"])
+        raise HTTPException(status_code=500, detail="Credential listing failed")
     return results
 
 
@@ -96,7 +101,8 @@ def verify_credential_external(
     """
     result = svc.verify_credential_external(body.credential)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("External credential verification failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Credential verification failed")
     return result
 
 
@@ -120,7 +126,8 @@ def verify_credential(
     """Verify a credential by ID: check signature, expiry, and revocation."""
     result = svc.verify_credential(credential_id)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Credential verification failed for %s: %s", credential_id, result["error"])
+        raise HTTPException(status_code=400, detail="Credential verification failed")
     return result
 
 
@@ -134,9 +141,11 @@ def revoke_credential(
     reason = body.reason if body else ""
     result = svc.revoke_credential(credential_id, reason=reason)
     if isinstance(result, dict) and "error" in result:
-        if "not found" in result["error"].lower():
-            raise HTTPException(status_code=404, detail=result["error"])
-        raise HTTPException(status_code=400, detail=result["error"])
+        error_msg = result["error"]
+        logger.warning("Credential revocation failed for %s: %s", credential_id, error_msg)
+        if "not found" in error_msg.lower():
+            raise HTTPException(status_code=404, detail="Credential not found")
+        raise HTTPException(status_code=400, detail="Credential revocation failed")
     return result
 
 
@@ -157,7 +166,9 @@ def create_verifiable_presentation(
         challenge=body.challenge,
     )
     if isinstance(result, dict) and "error" in result:
-        if "not found" in result["error"].lower():
-            raise HTTPException(status_code=404, detail=result["error"])
-        raise HTTPException(status_code=400, detail=result["error"])
+        error_msg = result["error"]
+        logger.warning("Verifiable presentation creation failed: %s", error_msg)
+        if "not found" in error_msg.lower():
+            raise HTTPException(status_code=404, detail="Credential or agent not found")
+        raise HTTPException(status_code=400, detail="Verifiable presentation creation failed")
     return result

--- a/api/routers/identity.py
+++ b/api/routers/identity.py
@@ -4,13 +4,16 @@ Manages Unified Agent Identity Tokens (UAITs): create, read, list,
 verify, translate, revoke, and GDPR purge.
 """
 
+import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from api.deps import get_identity_service
 from services.identity_service import IdentityService
+
+logger = logging.getLogger("attestix.api.identity")
 
 router = APIRouter(prefix="/v1/identities", tags=["identity"])
 
@@ -19,14 +22,41 @@ router = APIRouter(prefix="/v1/identities", tags=["identity"])
 # Request / Response models
 # ---------------------------------------------------------------------------
 
+#: Maximum allowed length for an agent display name (defense in depth against
+#: UI abuse, log-injection, and storage bloat).
+MAX_DISPLAY_NAME_LENGTH = 500
+
+
 class CreateIdentityRequest(BaseModel):
-    display_name: str = Field(..., description="Human-readable name for the agent")
+    display_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_DISPLAY_NAME_LENGTH,
+        description="Human-readable name for the agent (1-500 characters, non-empty)",
+    )
     source_protocol: str = Field(..., description="Identity source protocol (e.g., oauth2, api_key, did)")
     identity_token: str = Field("", description="Optional identity token to extract info from")
     capabilities: Optional[List[str]] = Field(None, description="List of capability strings")
     description: str = Field("", description="Description of the agent")
     issuer_name: str = Field("", description="Name of the identity issuer")
     expiry_days: Optional[int] = Field(None, description="Days until the identity expires")
+
+    @field_validator("display_name")
+    @classmethod
+    def _validate_display_name(cls, value: str) -> str:
+        if value is None:
+            raise ValueError("display_name is required")
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("display_name must not be empty or whitespace-only")
+        if len(stripped) > MAX_DISPLAY_NAME_LENGTH:
+            raise ValueError(
+                f"display_name must be at most {MAX_DISPLAY_NAME_LENGTH} characters"
+            )
+        # Reject control characters that could break logs, JSON, or terminals.
+        if any(ord(ch) < 0x20 and ch not in ("\t",) for ch in stripped):
+            raise ValueError("display_name contains disallowed control characters")
+        return stripped
 
 
 class TranslateIdentityRequest(BaseModel):
@@ -60,7 +90,8 @@ def create_identity(
         expiry_days=body.expiry_days,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Identity creation failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Identity creation failed")
     return result
 
 
@@ -111,7 +142,11 @@ def translate_identity(
     if result is None:
         raise HTTPException(status_code=404, detail=f"Identity {agent_id} not found")
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning(
+            "Identity translation failed for %s: %s",
+            agent_id, result["error"],
+        )
+        raise HTTPException(status_code=400, detail="Identity translation failed")
     return result
 
 
@@ -137,5 +172,9 @@ def purge_agent_data(
     """GDPR Article 17 - Right to erasure. Purge all data for an agent."""
     result = svc.purge_agent_data(agent_id)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning(
+            "Agent data purge failed for %s: %s",
+            agent_id, result["error"],
+        )
+        raise HTTPException(status_code=400, detail="Agent data purge failed")
     return result

--- a/api/routers/provenance.py
+++ b/api/routers/provenance.py
@@ -4,6 +4,7 @@ Manages training data provenance, model lineage tracking, and
 Article 12 EU AI Act automatic action logging (audit trail).
 """
 
+import logging
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -11,6 +12,8 @@ from pydantic import BaseModel, Field
 
 from api.deps import get_provenance_service
 from services.provenance_service import ProvenanceService
+
+logger = logging.getLogger("attestix.api.provenance")
 
 router = APIRouter(prefix="/v1/provenance", tags=["provenance"])
 
@@ -66,7 +69,8 @@ def record_training_data(
         data_governance_measures=body.data_governance_measures,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Training data recording failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Training data recording failed")
     return result
 
 
@@ -84,7 +88,8 @@ def record_model_lineage(
         evaluation_metrics=body.evaluation_metrics,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Model lineage recording failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Model lineage recording failed")
     return result
 
 
@@ -103,7 +108,8 @@ def log_action(
         human_override=body.human_override,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Action logging failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Action logging failed")
     return result
 
 
@@ -125,7 +131,8 @@ def get_audit_trail(
         limit=limit,
     )
     if results and isinstance(results[0], dict) and "error" in results[0]:
-        raise HTTPException(status_code=500, detail=results[0]["error"])
+        logger.error("Audit trail query failed: %s", results[0]["error"])
+        raise HTTPException(status_code=500, detail="Audit trail query failed")
     return results
 
 
@@ -137,5 +144,6 @@ def get_provenance(
     """Get full provenance record for an agent (training data, model lineage, audit summary)."""
     result = svc.get_provenance(agent_id)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=500, detail=result["error"])
+        logger.error("Provenance lookup failed for %s: %s", agent_id, result["error"])
+        raise HTTPException(status_code=500, detail="Provenance lookup failed")
     return result

--- a/api/routers/reputation.py
+++ b/api/routers/reputation.py
@@ -4,6 +4,7 @@ Records agent interactions and queries recency-weighted trust scores
 with exponential decay (30-day half-life).
 """
 
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -11,6 +12,8 @@ from pydantic import BaseModel, Field
 
 from api.deps import get_reputation_service
 from services.reputation_service import ReputationService
+
+logger = logging.getLogger("attestix.api.reputation")
 
 router = APIRouter(prefix="/v1/reputation", tags=["reputation"])
 
@@ -45,7 +48,8 @@ def record_interaction(
         details=body.details,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
+        logger.warning("Interaction recording failed: %s", result["error"])
+        raise HTTPException(status_code=400, detail="Interaction recording failed")
     return result
 
 
@@ -57,7 +61,8 @@ def get_reputation(
     """Get the current trust score and category breakdown for an agent."""
     result = svc.get_reputation(agent_id)
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(status_code=500, detail=result["error"])
+        logger.error("Reputation lookup failed for %s: %s", agent_id, result["error"])
+        raise HTTPException(status_code=500, detail="Reputation lookup failed")
     return result
 
 
@@ -79,5 +84,6 @@ def query_reputation(
         limit=limit,
     )
     if results and isinstance(results[0], dict) and "error" in results[0]:
-        raise HTTPException(status_code=500, detail=results[0]["error"])
+        logger.error("Reputation query failed: %s", results[0]["error"])
+        raise HTTPException(status_code=500, detail="Reputation query failed")
     return results

--- a/auth/crypto.py
+++ b/auth/crypto.py
@@ -5,6 +5,9 @@ Handles key generation, signing, verification, and did:key creation.
 
 import base64
 import json
+import os
+import stat
+import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -195,6 +198,18 @@ def load_or_create_signing_key(
 
     with open(key_path, "w") as f:
         json.dump(key_data, f, indent=2)
+
+    # Restrict file permissions so the private key material is only readable
+    # by the owning user. Skipped on Windows where POSIX mode bits do not
+    # map cleanly; rely on filesystem ACLs there instead.
+    if sys.platform != "win32":
+        try:
+            os.chmod(key_path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+        except OSError as chmod_err:
+            log_and_format_error(
+                "load_or_create_signing_key", chmod_err, ErrorCategory.CRYPTO,
+                user_message="Could not restrict signing key permissions to 0600",
+            )
 
     return private_key, did
 

--- a/services/agent_card_service.py
+++ b/services/agent_card_service.py
@@ -31,8 +31,19 @@ class AgentCardService:
 
             agent_json_url = f"{url}/.well-known/agent.json"
 
-            with httpx.Client(timeout=10, follow_redirects=True) as client:
+            # SSRF protection: disable automatic redirects. A public server could
+            # otherwise redirect us to an internal IP (e.g. 169.254.169.254,
+            # 10.0.0.1) bypassing the initial hostname validation above.
+            with httpx.Client(timeout=10, follow_redirects=False) as client:
                 resp = client.get(agent_json_url)
+                if resp.is_redirect:
+                    return {
+                        "error": (
+                            "Redirect responses are not followed during agent "
+                            "discovery to prevent SSRF. Provide the canonical URL."
+                        ),
+                        "source_url": agent_json_url,
+                    }
                 resp.raise_for_status()
                 card = resp.json()
 

--- a/services/delegation_service.py
+++ b/services/delegation_service.py
@@ -240,7 +240,15 @@ class DelegationService:
         except jwt.ExpiredSignatureError:
             return {"valid": False, "reason": "Token has expired"}
         except jwt.InvalidTokenError as e:
-            return {"valid": False, "reason": f"Invalid token: {str(e)}"}
+            # Log the underlying PyJWT error server-side (may include
+            # "Signature verification failed", "Not enough segments", etc.)
+            # but return a generic message so internal token internals don't
+            # leak to API callers.
+            log_and_format_error(
+                "verify_delegation", e, ErrorCategory.DELEGATION,
+                user_message="Invalid delegation token",
+            )
+            return {"valid": False, "reason": "Invalid token"}
         except Exception as e:
             return {
                 "valid": False,

--- a/services/identity_service.py
+++ b/services/identity_service.py
@@ -26,6 +26,11 @@ from config import (
 from errors import ErrorCategory, log_and_format_error
 
 
+#: Maximum allowed display_name length. Mirrors the API layer constraint so
+#: programmatic callers that bypass FastAPI still get a validation error.
+MAX_DISPLAY_NAME_LENGTH = 500
+
+
 class IdentityService:
     """Manages UAIT lifecycle."""
 
@@ -62,6 +67,23 @@ class IdentityService:
         expiry_days: Optional[int] = None,
     ) -> dict:
         """Create a new UAIT from any identity source."""
+        # Defense in depth: validate even when callers skip the API layer.
+        # Issue #32 - reject empty/whitespace/overlong display_name.
+        if display_name is None:
+            raise ValueError("display_name is required")
+        if not isinstance(display_name, str):
+            raise ValueError("display_name must be a string")
+        stripped = display_name.strip()
+        if not stripped:
+            raise ValueError("display_name must not be empty or whitespace-only")
+        if len(stripped) > MAX_DISPLAY_NAME_LENGTH:
+            raise ValueError(
+                f"display_name must be at most {MAX_DISPLAY_NAME_LENGTH} characters"
+            )
+        if any(ord(ch) < 0x20 and ch != "\t" for ch in stripped):
+            raise ValueError("display_name contains disallowed control characters")
+        display_name = stripped
+
         agent_id = f"attestix:{uuid.uuid4().hex[:16]}"
         now = datetime.now(timezone.utc)
         exp_days = expiry_days if expiry_days is not None else DEFAULT_EXPIRY_DAYS

--- a/tests/unit/test_security_hardening.py
+++ b/tests/unit/test_security_hardening.py
@@ -1,0 +1,244 @@
+"""Regression tests for the security hardening batch.
+
+Covers:
+    - Fix 1: SSRF redirect bypass (agent_card_service)
+    - Fix 2: API key constant-time comparison (api/main.py)
+    - Fix 3: Exception info leakage (log full, return generic)
+    - Fix 4: display_name validation (empty / whitespace / overlong)
+    - Fix 5: Signing key POSIX 0600 permissions
+    - Fix 6: JWT error leak in delegation verification
+"""
+
+import hmac
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from auth.crypto import load_or_create_signing_key
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 - SSRF redirect bypass
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardRedirectProtection:
+    """The discover_agent client must not follow redirects, else a public
+    server could redirect us to 169.254.169.254 or another internal IP
+    bypassing the initial SSRF host validation."""
+
+    def test_client_has_follow_redirects_disabled(self, monkeypatch):
+        """Ensure the httpx.Client used in discover_agent sets
+        follow_redirects=False."""
+        from services.agent_card_service import AgentCardService
+
+        captured = {}
+
+        def fake_client(*args, **kwargs):
+            captured["follow_redirects"] = kwargs.get("follow_redirects")
+            # Fail before making any real network call.
+            raise httpx.TimeoutException("short-circuit for test")
+
+        monkeypatch.setattr(httpx, "Client", fake_client)
+
+        svc = AgentCardService()
+        result = svc.discover_agent("https://example.com")
+
+        assert captured.get("follow_redirects") is False
+        assert "error" in result
+
+    def test_redirect_response_is_refused(self, monkeypatch):
+        """A 30x response must short-circuit to an error, not be silently
+        followed."""
+        from services.agent_card_service import AgentCardService
+
+        class FakeResp:
+            status_code = 302
+            is_redirect = True
+            headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {}
+
+        class FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def get(self, url):
+                return FakeResp()
+
+        monkeypatch.setattr(httpx, "Client", FakeClient)
+
+        svc = AgentCardService()
+        result = svc.discover_agent("https://example.com")
+        assert "error" in result
+        assert "redirect" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 - API key constant-time comparison
+# ---------------------------------------------------------------------------
+
+
+class TestAPIKeyMiddleware:
+    """APIKeyMiddleware must use hmac.compare_digest to avoid byte-by-byte
+    timing attacks that reveal the configured key."""
+
+    def test_module_imports_hmac(self):
+        """Static check that api/main.py imports hmac."""
+        src = Path("api/main.py").read_text(encoding="utf-8")
+        assert "import hmac" in src
+        # Sanity: the compare_digest symbol is what we rely on.
+        assert hmac.compare_digest("abc", "abc") is True
+        assert hmac.compare_digest("abc", "abd") is False
+
+    def test_source_uses_compare_digest(self):
+        """Static check: the middleware must not use plain == on the keys."""
+        src = Path("api/main.py").read_text(encoding="utf-8")
+        assert "hmac.compare_digest(provided_key, api_key)" in src
+        assert "provided_key != api_key" not in src
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 - Exception info leakage
+# ---------------------------------------------------------------------------
+
+
+class TestRoutersDoNotLeakInternalErrors:
+    """The error-handling routers must not pass raw service error strings
+    straight back to the HTTP caller. A greppable check keeps this honest."""
+
+    ROUTER_FILES = [
+        "api/routers/agent_cards.py",
+        "api/routers/blockchain.py",
+        "api/routers/compliance.py",
+        "api/routers/credentials.py",
+        "api/routers/identity.py",
+        "api/routers/provenance.py",
+        "api/routers/reputation.py",
+    ]
+
+    def test_no_raw_error_detail_in_routers(self):
+        offenders = []
+        for path in self.ROUTER_FILES:
+            src = Path(path).read_text(encoding="utf-8")
+            if 'detail=result["error"]' in src:
+                offenders.append(path)
+            if 'detail=results[0]["error"]' in src:
+                offenders.append(path)
+        assert not offenders, (
+            "Routers still leak raw service errors to HTTP callers: "
+            f"{offenders}"
+        )
+
+    def test_routers_log_before_responding(self):
+        """Every sanitized router must keep the original error in the logs."""
+        for path in self.ROUTER_FILES:
+            src = Path(path).read_text(encoding="utf-8")
+            assert "logger" in src, f"{path} should log errors server-side"
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 - display_name validation
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayNameValidation:
+    """IdentityService.create_identity must reject empty/whitespace-only
+    and overlong display_name values (Issue #32)."""
+
+    def test_rejects_empty_string(self, identity_service):
+        with pytest.raises(ValueError):
+            identity_service.create_identity(
+                display_name="",
+                source_protocol="mcp",
+            )
+
+    def test_rejects_whitespace_only(self, identity_service):
+        with pytest.raises(ValueError):
+            identity_service.create_identity(
+                display_name="   \t  ",
+                source_protocol="mcp",
+            )
+
+    def test_rejects_overlong(self, identity_service):
+        with pytest.raises(ValueError):
+            identity_service.create_identity(
+                display_name="x" * 501,
+                source_protocol="mcp",
+            )
+
+    def test_strips_surrounding_whitespace(self, identity_service):
+        result = identity_service.create_identity(
+            display_name="  Alice  ",
+            source_protocol="mcp",
+        )
+        assert result["display_name"] == "Alice"
+
+    def test_rejects_control_characters(self, identity_service):
+        with pytest.raises(ValueError):
+            identity_service.create_identity(
+                display_name="bad\x00name",
+                source_protocol="mcp",
+            )
+
+    def test_accepts_max_length(self, identity_service):
+        name = "a" * 500
+        result = identity_service.create_identity(
+            display_name=name,
+            source_protocol="mcp",
+        )
+        assert result["display_name"] == name
+
+
+# ---------------------------------------------------------------------------
+# Fix 5 - Signing key file permissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX chmod only")
+class TestSigningKeyPermissions:
+    def test_newly_generated_key_is_0600(self, tmp_path):
+        key_file = tmp_path / "signing_key.json"
+        load_or_create_signing_key(key_file=key_file)
+        assert key_file.exists()
+        mode = key_file.stat().st_mode
+        perm = mode & 0o777
+        assert perm == 0o600, f"expected 0600, got {oct(perm)}"
+
+
+class TestSigningKeyPermissionsWindowsSafe:
+    def test_chmod_is_skipped_on_windows(self):
+        """The code path must not crash on Windows even though chmod is a
+        no-op for POSIX mode bits there."""
+        src = Path("auth/crypto.py").read_text(encoding="utf-8")
+        assert 'sys.platform != "win32"' in src
+        assert "os.chmod(key_path" in src
+
+
+# ---------------------------------------------------------------------------
+# Fix 6 - JWT error leak in delegation verification
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationInvalidTokenIsGeneric:
+    """verify_delegation must return a generic 'Invalid token' reason
+    rather than echoing PyJWT's internal error message."""
+
+    def test_malformed_token_returns_generic_reason(self, delegation_service):
+        result = delegation_service.verify_delegation("not-a-real-jwt")
+        assert result["valid"] is False
+        assert result["reason"] == "Invalid token"
+        assert "segments" not in result["reason"].lower()
+        assert "signature" not in result["reason"].lower()

--- a/tools/identity_tools.py
+++ b/tools/identity_tools.py
@@ -44,15 +44,20 @@ def register(mcp):
 
         svc = get_service(IdentityService)
         caps = [c.strip() for c in capabilities.split(",") if c.strip()] if capabilities else []
-        result = svc.create_identity(
-            display_name=display_name,
-            source_protocol=source_protocol,
-            identity_token=identity_token,
-            capabilities=caps,
-            description=description,
-            issuer_name=issuer_name,
-            expiry_days=expiry_days,
-        )
+        try:
+            result = svc.create_identity(
+                display_name=display_name,
+                source_protocol=source_protocol,
+                identity_token=identity_token,
+                capabilities=caps,
+                description=description,
+                issuer_name=issuer_name,
+                expiry_days=expiry_days,
+            )
+        except ValueError as ve:
+            # Input validation errors from the service layer (Issue #32).
+            # Surface them as a structured error rather than crashing the tool.
+            result = {"error": str(ve)}
         return json.dumps(result, indent=2, default=str)
 
     @mcp.tool()
@@ -68,11 +73,14 @@ def register(mcp):
 
         token_info = extract_identity_from_token(identity_token)
         svc = get_service(IdentityService)
-        result = svc.create_identity(
-            display_name=f"Resolved-{token_info['token_type']}",
-            source_protocol=token_info["token_type"],
-            identity_token=identity_token,
-        )
+        try:
+            result = svc.create_identity(
+                display_name=f"Resolved-{token_info['token_type']}",
+                source_protocol=token_info["token_type"],
+                identity_token=identity_token,
+            )
+        except ValueError as ve:
+            result = {"error": str(ve)}
         return json.dumps(result, indent=2, default=str)
 
     @mcp.tool()


### PR DESCRIPTION
## Summary

Six independent security fixes bundled into one hardening pass. Each is low-risk on its own but meaningful defense-in-depth:

1. **SSRF redirect bypass** (services/agent_card_service.py) - httpx.Client set follow_redirects=True, so after the initial hostname passed SSRF validation a controlled server could 30x-redirect discovery at 169.254.169.254 or 10.0.0.1. Client now uses follow_redirects=False and returns an error on 30x.
2. **API key timing attack** (api/main.py) - APIKeyMiddleware compared keys with == which short-circuits byte-by-byte. Replaced with hmac.compare_digest.
3. **Exception info leakage across 7 routers** (agent_cards, blockchain, compliance, credentials, identity, provenance, reputation) - raw service error strings were flowing into HTTPException.detail, leaking internal state. Each router now logs the full error server-side and returns a generic category-specific message to the caller, matching the pattern already used by did.py and delegation.py.
4. **display_name validation** (Issue #32) - CreateIdentityRequest (API) and IdentityService.create_identity (service layer, defense in depth) now reject empty, whitespace-only, control-character-bearing, and overlong (>500 char) display_name values. MCP tool layer converts the ValueError to a structured error dict.
5. **Signing key permissions** (auth/crypto.py) - newly written Ed25519 private key JSON is now chmod 0600 on POSIX. Skipped on Windows where POSIX mode bits do not apply.
6. **JWT error leak** (services/delegation_service.py) - verify_delegation was returning `Invalid token: {PyJWT internal message}`. Now returns generic `Invalid token` and logs the underlying error server-side.

## Test plan

- [x] Added tests/unit/test_security_hardening.py with 15 regression tests covering every fix (one POSIX-only chmod test is skipped on Windows)
- [x] Full unit + integration + e2e suite: 337 passed, 1 skipped, 0 failed on Windows
- [x] Greppable check: no router contains `detail=result["error"]` or `detail=results[0]["error"]` any more
- [x] hmac.compare_digest confirmed as the API key comparison primitive
- [x] Malformed JWT returns exactly `"Invalid token"` (no PyJWT leakage)
- [x] display_name accepts max 500 characters, rejects empty / whitespace / control chars