### PR TITLE
fix(ci): drop environment gate and id-token from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   build:
@@ -55,9 +54,6 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/attestix/
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Fixes the startup_failure on the v0.3.0 publish run. Removes the environment: pypi gate and id-token: write permission since we publish via PYPI_API_TOKEN secret, not OIDC trusted publishing.