### PR TITLE
fix(ci): collapse publish workflow into a single job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,9 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build sdist and wheel
+  publish:
+    name: Build and publish to PyPI
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -22,8 +20,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
 
       - name: Install build tooling
         run: |
@@ -36,53 +32,15 @@ jobs:
       - name: Verify distributions with twine
         run: twine check dist/*
 
-      - name: Extract package version
-        id: version
-        run: |
-          VERSION=$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-          if-no-files-found: error
-          retention-days: 14
-
-  publish-pypi:
-    name: Publish to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
-      - name: Publish via API token
-        # Uses PYPI_API_TOKEN secret. Trusted Publishing (id-token) can be
-        # enabled later by dropping the password field.
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
           verbose: true
 
-  attach-release-assets:
-    name: Attach dist to GitHub Release
-    needs: build
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
-      - name: Upload dist/* to release
+      - name: Upload dist to GitHub Release
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*


### PR DESCRIPTION
Rolls back to the v0.2.5-era single-job shape that successfully published. Multi-job variant was hitting startup_failure with 0 jobs and no logs on both release and workflow_dispatch.