### PR TITLE
fix(ci): restore PyPI token auth to unblock v0.3.0 publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,15 +6,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/attestix/
     steps:
       - uses: actions/checkout@v4
 
@@ -31,4 +27,6 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
+          verbose: true


### PR DESCRIPTION
## Summary

Five consecutive publish.yml runs failed with startup_failure and PyPI is still on 0.2.5 despite v0.3.0 being tagged and released on GitHub.

Root cause: PR #55 accidentally reintroduced a workflow configuration that relies on PyPI Trusted Publishing (OIDC via id-token write plus a pypi environment gate) without PyPI Trusted Publishing actually being configured for this project. Earlier commits 4605a7a and b96bf1d had already fixed this, but were overwritten.

This change restores explicit password auth using the PYPI_API_TOKEN secret, which is already present in the repo, and drops the OIDC bits plus the environment gate so the job can start cleanly.

## Changes

1. Drop id-token write permission
2. Drop environment: pypi gate
3. Pass password: secrets.PYPI_API_TOKEN to pypa/gh-action-pypi-publish
4. Enable verbose for easier diagnostics

## Test plan

- [ ] Merge this PR to main
- [ ] Run workflow via workflow_dispatch on main
- [ ] Verify run reaches the Publish step (no startup_failure)
- [ ] Confirm attestix 0.3.0 appears on https://pypi.org/project/attestix/
- [ ] Run pip index versions attestix and see 0.3.0