### PR TITLE
docs: pre-YC Bengaluru cleanup (links, test counts, REST API, AutoGen clarity)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Open an issue on GitHub with:
 3. Make your changes
 4. Run the test suite to verify nothing is broken:
    ```bash
-   # Run all 284 tests (unit, e2e, conformance benchmarks)
+   # Run all 358 tests (unit, e2e, conformance benchmarks; 1 skipped on Windows)
    pytest tests/ -v -m "not live_blockchain"
 
    # Or run in Docker for a clean environment

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Full documentation at **[attestix.io/docs](https://attestix.io/docs)**
 | [Risk Classification](https://attestix.io/docs/guides/risk-classification) | How to determine your AI system's risk category |
 | [Architecture](https://attestix.io/docs/guides/architecture) | System design and data flows |
 | [API Reference](https://attestix.io/docs/reference/api-reference) | All 47 tools with parameter tables |
-| [Integration Guide](https://attestix.io/docs/guides/integration-guide) | LangChain, CrewAI, AutoGen, MCP client |
+| [Integration Guide](https://attestix.io/docs/guides/integration-guide) | LangChain, OpenAI Agents SDK, CrewAI, MCP client |
 | [Configuration](https://attestix.io/docs/reference/configuration) | Environment variables, storage, Docker |
 | [Research Paper](https://attestix.io/docs/project/research) | Paper, citation formats, evaluation highlights |
 | [Reputation Scoring](https://attestix.io/docs/guides/reputation) | Recency-weighted trust scoring and categories |
@@ -465,7 +465,6 @@ Attestix generates machine-readable, cryptographically signed compliance documen
 
 Attestix is free and open-source. If you or your organization benefit from it, please consider sponsoring to support continued development, security audits, and infrastructure.
 
-<a href="https://polar.sh/VibeTensor"><img src="https://polar.sh/embed/seeks-funding-shield.svg?org=VibeTensor" alt="Sponsor on Polar" /></a>
 <a href="https://github.com/sponsors/VibeTensor"><img src="https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?style=flat-square&logo=github" alt="GitHub Sponsors" /></a>
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,7 +126,8 @@ Connect to existing agent identity ecosystems for interoperability.
 |---------|-------|--------|
 | 0.1.0 | Phase 1 + 2 | Initial release (36 tools) |
 | 0.2.0 | Phase 3 | Blockchain anchoring + security audit + conformance benchmarks (47 tools, 284 tests) |
-| 0.3.0 | Phase 4 | ERC-8004, A2A sync, ANS |
-| 0.4.0 | Phase 4 | Polygon ID / ZK credentials |
+| 0.3.0 | Phase 3.5 | Real LangChain/OpenAI Agents/CrewAI integrations, CI/CD, security hardening (358 tests, 1 skipped on Windows) |
+| 0.4.0 | Phase 4 | ERC-8004, A2A sync, ANS |
+| 0.4.1 | Phase 4 | Polygon ID / ZK credentials |
 | 0.5.0 | Phase 5 | Multi-chain + enterprise storage |
 | 1.0.0 | Stable | Production-ready with full test suite and third-party audit |

--- a/demo/presentation/comparison-table.md
+++ b/demo/presentation/comparison-table.md
@@ -97,7 +97,7 @@
 
 4. **Offline-first, zero vendor lock-in.** All core operations work without internet. Data stays local. Open source under Apache 2.0. No subscription fees.
 
-5. **MCP-native integration.** Direct integration with Claude, LangChain, CrewAI, AutoGen, and any MCP-compatible client. No custom API integration needed.
+5. **MCP-native integration.** Direct integration with Claude, LangChain, OpenAI Agents SDK, CrewAI, and any MCP-compatible client. No custom API integration needed.
 
 6. **Blockchain timestamping.** Immutable proof of existence via EAS on Base L2. Sub-cent anchoring costs. No other AI compliance tool offers on-chain evidence anchoring.
 

--- a/demo/presentation/faq.md
+++ b/demo/presentation/faq.md
@@ -10,7 +10,7 @@ Attestix is an open-source attestation infrastructure that gives AI agents crypt
 
 ### 2. What is the total addressable market?
 
-The AI governance market is projected to reach $4.5B - $7B by 2028 (Gartner, McKinsey estimates). More specifically, every company deploying AI agents in the EU or serving EU customers will need compliance tooling by August 2, 2026. The EU AI Act applies to AI systems "placed on the market or put into service in the Union," which includes non-EU companies serving EU users. The initial beachhead is AI agent developers using MCP-compatible frameworks (Claude, LangChain, CrewAI, AutoGen), estimated at hundreds of thousands of developers globally.
+The AI governance market is projected to reach $4.5B - $7B by 2028 (Gartner, McKinsey estimates). More specifically, every company deploying AI agents in the EU or serving EU customers will need compliance tooling by August 2, 2026. The EU AI Act applies to AI systems "placed on the market or put into service in the Union," which includes non-EU companies serving EU users. The initial beachhead is AI agent developers using MCP-compatible frameworks (Claude, LangChain, OpenAI Agents SDK, CrewAI), estimated at hundreds of thousands of developers globally.
 
 ### 3. What is the business model?
 
@@ -22,7 +22,7 @@ The main competitors are Credo AI ($22.8M raised), Holistic AI (acquired by Delo
 
 ### 5. What traction do you have?
 
-Attestix is published on PyPI (pip install attestix), registered in the MCP Registry (io.github.VibeTensor/attestix), and has a research paper describing the system architecture and evaluation. The project has 284 automated tests including 91 conformance benchmarks validating standards compliance. Early validation includes direct encouragement from Yoshua Bengio (Turing Award, MILA) and business case validation from Matt Pagett (AI safety researcher, NANDA/CBAAC contributor).
+Attestix is published on PyPI (pip install attestix), registered in the MCP Registry (io.github.VibeTensor/attestix), and has a research paper describing the system architecture and evaluation. The project has 358 automated tests (1 skipped on Windows) including 91 conformance benchmarks validating standards compliance. Early validation includes direct encouragement from Yoshua Bengio (Turing Award, MILA) and business case validation from Matt Pagett (AI safety researcher, NANDA/CBAAC contributor).
 
 ### 6. What is the regulatory catalyst?
 
@@ -30,7 +30,7 @@ The EU AI Act enforcement begins August 2, 2026. Fines reach EUR 35 million or 7
 
 ### 7. What is the go-to-market strategy?
 
-Bottom-up developer adoption through open source, PyPI distribution, and MCP Registry integration. Developers install Attestix, use it in their agent workflows, and it becomes embedded in their stack. Enterprise conversion happens when compliance teams discover their engineering teams are already using Attestix and need managed features. Secondary GTM through partnerships with AI agent frameworks (LangChain, CrewAI, AutoGen) and notified bodies performing EU AI Act assessments.
+Bottom-up developer adoption through open source, PyPI distribution, and MCP Registry integration. Developers install Attestix, use it in their agent workflows, and it becomes embedded in their stack. Enterprise conversion happens when compliance teams discover their engineering teams are already using Attestix and need managed features. Secondary GTM through partnerships with AI agent frameworks (LangChain, OpenAI Agents SDK, CrewAI) and notified bodies performing EU AI Act assessments.
 
 ---
 
@@ -38,7 +38,7 @@ Bottom-up developer adoption through open source, PyPI distribution, and MCP Reg
 
 ### 8. How do we integrate Attestix into our existing agent infrastructure?
 
-Three integration paths: (1) as an MCP server that works with any MCP-compatible client (Claude Code, Claude Desktop, custom MCP clients), (2) as a Python library imported directly into your code (from services.identity_service import IdentityService), or (3) as a standalone service behind your API gateway. Integration with LangChain, CrewAI, and AutoGen is documented. A REST API is on the roadmap. Typical integration takes less than a day.
+Three integration paths: (1) as an MCP server that works with any MCP-compatible client (Claude Code, Claude Desktop, custom MCP clients), (2) as a Python library imported directly into your code (from services.identity_service import IdentityService), or (3) as a standalone service behind your API gateway. Integration with LangChain, OpenAI Agents SDK, and CrewAI is documented. A REST API is on the roadmap. Typical integration takes less than a day.
 
 ### 9. Where is our data stored?
 
@@ -46,7 +46,7 @@ All data stays in your environment. By default, Attestix stores data in local JS
 
 ### 10. What security guarantees does Attestix provide?
 
-Every artifact is signed with Ed25519 (RFC 8032). Audit trails are hash-chained with SHA-256 for tamper evidence. Private keys can be encrypted with AES-256-GCM using the ATTESTIX_KEY_PASSWORD environment variable. SSRF protection blocks private IP access, metadata endpoints, and DNS rebinding. Private keys are never exposed in tool responses. The codebase has 284 automated tests including cryptographic conformance benchmarks validated against IETF test vectors.
+Every artifact is signed with Ed25519 (RFC 8032). Audit trails are hash-chained with SHA-256 for tamper evidence. Private keys can be encrypted with AES-256-GCM using the ATTESTIX_KEY_PASSWORD environment variable. SSRF protection blocks private IP access, metadata endpoints, and DNS rebinding. Private keys are never exposed in tool responses. The codebase has 358 automated tests (1 skipped on Windows) including cryptographic conformance benchmarks validated against IETF test vectors.
 
 ### 11. Does using Attestix guarantee we are EU AI Act compliant?
 

--- a/demo/presentation/one-pager.md
+++ b/demo/presentation/one-pager.md
@@ -14,7 +14,7 @@ The EU AI Act begins enforcement on August 2, 2026, with fines up to EUR 35 mill
 - **Agent-native identity.** W3C DIDs and Verifiable Credentials designed for machine-to-machine trust, not human reviewers clicking through checklists.
 - **EU AI Act enforcement built in.** Automatically blocks prohibited systems (Article 5) and prevents self-assessment for high-risk systems (Article 43).
 - **Offline-first, zero vendor lock-in.** All core operations work without internet. Data stays local. Fully open source under Apache 2.0.
-- **MCP-native with 47 tools.** Direct integration with Claude, LangChain, CrewAI, AutoGen, and any MCP-compatible client.
+- **MCP-native with 47 tools.** Direct integration with Claude, LangChain, OpenAI Agents SDK, CrewAI, and any MCP-compatible client.
 
 ## How It Works
 
@@ -26,11 +26,11 @@ The EU AI Act begins enforcement on August 2, 2026, with fines up to EUR 35 mill
 
 ## Standards
 
-W3C Verifiable Credentials 1.1 / W3C DID Core 1.0 / UCAN v0.9.0 / Ed25519 (RFC 8032) / JSON Canonicalization (RFC 8785) / Ethereum Attestation Service / Base L2 / Merkle Trees (RFC 6962) / EU AI Act (13 articles + Annex III + Annex V) / GDPR Article 17
+W3C Verifiable Credentials 1.1 / W3C DID Core 1.0 / UCAN v0.9.0 / Ed25519 (RFC 8032) / JSON Canonicalization (RFC 8785) / Ethereum Attestation Service / Base L2 / Merkle Trees (RFC 6962) / EU AI Act (11 articles + Annex III + Annex V) / GDPR Article 17
 
 ## By the Numbers
 
-47 MCP tools / 9 modules / 284 automated tests / 91 conformance benchmarks / 25 standards implemented / Sub-millisecond cryptographic operations / Apache 2.0 license
+47 MCP tools / 9 modules / 358 automated tests (1 skipped on Windows) / 91 conformance benchmarks / 25 standards implemented / Sub-millisecond cryptographic operations / Apache 2.0 license
 
 ## Business Model
 

--- a/demo/presentation/talking-points.md
+++ b/demo/presentation/talking-points.md
@@ -188,7 +188,7 @@ Run the VP creation command.
 
 "Let me recap what you just saw. Attestix provides end-to-end EU AI Act compliance automation for AI agents. 47 MCP tools across 9 modules. W3C Verifiable Credentials. Ed25519 cryptographic signatures. UCAN delegation chains. Blockchain anchoring on Base L2. Everything open-source under Apache 2.0."
 
-"We have 284 automated tests, including 91 conformance benchmarks that validate every standards claim against the actual specifications - RFC 8032 for Ed25519, W3C VC Data Model 1.1, W3C DID Core 1.0, UCAN v0.9.0."
+"We have 358 automated tests (1 skipped on Windows), including 91 conformance benchmarks that validate every standards claim against the actual specifications - RFC 8032 for Ed25519, W3C VC Data Model 1.1, W3C DID Core 1.0, UCAN v0.9.0."
 
 "The enforcement deadline is August 2, 2026. Every company deploying AI agents in the EU needs this. We are available on PyPI as 'attestix', registered in the MCP Registry, and documented at attestix.io/docs."
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -486,3 +486,102 @@ Estimate gas cost for anchoring an artifact.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `artifact_type` | string | Yes | - | `identity`, `credential`, or `audit_batch` |
+
+---
+
+## REST API (44 endpoints)
+
+Attestix ships a FastAPI-based HTTP API under `/v1/*`. Launch it with `uvicorn api.main:app` or via the Docker image. Interactive docs are served at `/docs` (Swagger UI) and `/redoc`.
+
+All endpoints accept and return JSON. Authentication is via the `Authorization: Bearer <token>` header when `ATTESTIX_API_AUTH_TOKEN` is configured.
+
+### Identity (7 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/identities` | Create a new UAIT |
+| GET | `/v1/identities` | List identities |
+| GET | `/v1/identities/{agent_id}` | Retrieve an identity |
+| POST | `/v1/identities/{agent_id}/verify` | Verify an identity's signature |
+| POST | `/v1/identities/{agent_id}/translate` | Translate identity between protocols |
+| DELETE | `/v1/identities/{agent_id}` | Revoke an identity |
+| DELETE | `/v1/identities/{agent_id}/purge` | GDPR Article 17 erasure |
+
+### Credentials (7 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/credentials` | Issue a W3C Verifiable Credential |
+| GET | `/v1/credentials` | List credentials |
+| POST | `/v1/credentials/verify-external` | Verify an externally supplied VC |
+| GET | `/v1/credentials/{credential_id}` | Retrieve a credential |
+| POST | `/v1/credentials/{credential_id}/verify` | Verify a stored credential |
+| DELETE | `/v1/credentials/{credential_id}` | Revoke a credential |
+| POST | `/v1/presentations` | Create a Verifiable Presentation |
+
+### Compliance (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/compliance/profiles` | Create a compliance profile |
+| GET | `/v1/compliance/profiles` | List compliance profiles |
+| GET | `/v1/compliance/profiles/{profile_id}` | Retrieve a profile |
+| GET | `/v1/compliance/profiles/{profile_id}/status` | Get profile compliance status |
+| POST | `/v1/compliance/assessments` | Record a conformity assessment |
+| POST | `/v1/compliance/declarations` | Generate Annex V Declaration of Conformity |
+
+### Reputation (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/reputation/interactions` | Record an interaction event |
+| GET | `/v1/reputation/{agent_id}` | Get reputation score for an agent |
+| GET | `/v1/reputation` | Query reputation across filters |
+
+### Provenance (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/provenance/training-data` | Record training data provenance |
+| POST | `/v1/provenance/model-lineage` | Record model lineage |
+| POST | `/v1/provenance/actions` | Log an agent action to the audit trail |
+| GET | `/v1/provenance/audit-trail/{agent_id}` | Retrieve hash-chained audit trail |
+| GET | `/v1/provenance/{agent_id}` | Retrieve provenance for an agent |
+
+### Delegation (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/delegations` | Create a UCAN delegation |
+| GET | `/v1/delegations` | List delegations |
+| POST | `/v1/delegations/verify` | Verify a delegation chain |
+| DELETE | `/v1/delegations/{delegation_id}` | Revoke a delegation |
+
+### DID (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/dids/key` | Create a `did:key` identifier |
+| POST | `/v1/dids/web` | Create a `did:web` identifier |
+| GET | `/v1/dids/resolve/{did}` | Resolve a DID document |
+
+### Agent Cards (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/agent-cards/discover` | Discover an A2A agent card by URL |
+| POST | `/v1/agent-cards/parse` | Parse a supplied agent card payload |
+| POST | `/v1/agent-cards/generate` | Generate an agent card for a UAIT |
+
+### Blockchain (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/blockchain/anchor/identity` | Anchor an identity on Base L2 |
+| POST | `/v1/blockchain/anchor/credential` | Anchor a credential |
+| POST | `/v1/blockchain/anchor/audit-batch` | Anchor a Merkle batch of audit events |
+| POST | `/v1/blockchain/verify/{anchor_id}` | Verify an on-chain anchor |
+| GET | `/v1/blockchain/anchors/{anchor_id}` | Retrieve anchor status |
+| GET | `/v1/blockchain/estimate-cost` | Estimate gas cost for an anchor |
+
+> Endpoint counts verified against `api/routers/*.py` on 2026-04-17. Total: 44 REST endpoints across 9 routers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,7 @@ Attestix uses environment variables for configuration. No config files needed. S
 
 ## Testing
 
-284 tests across unit, end-to-end, and conformance benchmark suites:
+358 tests across unit, end-to-end, and conformance benchmark suites (1 skipped on Windows):
 
 ```bash
 # Run all tests

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,7 +192,7 @@ docker run -v attestix-data:/data attestix
 
 ### Running the Test Suite
 
-The project includes `Dockerfile.test` which runs all 284 tests (unit, e2e, and conformance benchmarks) in a clean container:
+The project includes `Dockerfile.test` which runs all 358 tests (unit, e2e, and conformance benchmarks; 1 skipped on Windows) in a clean container:
 
 ```bash
 docker build -f Dockerfile.test -t attestix-bench . && docker run --rm attestix-bench

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ Open an issue on GitHub with:
 3. Make your changes
 4. Run the test suite to verify nothing is broken:
    ```bash
-   # Run all 284 tests (unit, e2e, conformance benchmarks)
+   # Run all 358 tests (unit, e2e, conformance benchmarks; 1 skipped on Windows)
    pytest tests/ -v -m "not live_blockchain"
 
    # Or run in Docker for a clean environment

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,4 +113,4 @@ print(result)
 - [EU AI Act Compliance Guide](eu-ai-act-compliance.md) - Full compliance workflow
 - [Concepts Explained](concepts.md) - What are UAITs, DIDs, VCs?
 - [API Reference](api-reference.md) - All 47 tools documented
-- [Integration Guide](integration-guide.md) - LangChain, CrewAI, AutoGen integrations
+- [Integration Guide](integration-guide.md) - LangChain, OpenAI Agents SDK, CrewAI integrations

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ flowchart TD
 - **Local-first** - No cloud dependency. All core operations work offline with JSON file storage
 - **Cryptographically signed** - Every artifact is signed with Ed25519. Anyone can verify without contacting Attestix
 - **Standards-based** - W3C Verifiable Credentials, W3C DIDs, UCAN delegation, A2A agent cards
-- **Vendor-neutral** - Works with any AI framework (LangChain, CrewAI, AutoGen, or plain Python)
+- **Vendor-neutral** - Works with any AI framework (LangChain, OpenAI Agents SDK, CrewAI, or plain Python)
 - **EU AI Act ready** - Risk classification, conformity assessments, Annex V declarations, Article 10/11/12 documentation
 
 ---

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -125,7 +125,9 @@ crew = Crew(agents=[compliance_officer], tasks=[audit_task])
 result = crew.kickoff()
 ```
 
-## With AutoGen
+## With AutoGen (Example Only)
+
+> Note: AutoGen is shown here as a usage example only. It is not part of the maintained real-integration test suite. Supported real integrations are LangChain, OpenAI Agents SDK, and CrewAI.
 
 ```python
 import autogen

--- a/docs/research.md
+++ b/docs/research.md
@@ -51,7 +51,7 @@ The paper presents four main contributions:
 
 2. **Compliance automation engine** implementing Articles 5, 9-15, 43, 72-73, and Annex V of the EU AI Act, including automated risk classification, conformity assessment enforcement, and declaration generation.
 
-3. **Open-source MCP implementation** with 47 tools validated by 284 automated tests (91 conformance benchmarks against RFC 8032, W3C VC, W3C DID, and UCAN specifications).
+3. **Open-source MCP implementation** with 47 tools validated by 358 automated tests (1 skipped on Windows; 91 conformance benchmarks against RFC 8032, W3C VC, W3C DID, and UCAN specifications).
 
 4. **Tamper-evident audit mechanism** combining SHA-256 hash-chained logs with Merkle tree aggregation and on-chain anchoring via the Ethereum Attestation Service on Base L2.
 

--- a/docs/risk-classification.md
+++ b/docs/risk-classification.md
@@ -129,6 +129,6 @@ If you are unsure about your risk category, consult with a legal professional sp
 ## Further Reading
 
 - [EU AI Act Full Text](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689)
-- [EU AI Act Annex III (High-Risk Categories)](https://artificialintelligenceact.eu/annex/iii/)
+- [EU AI Act Annex III (High-Risk Categories)](https://artificialintelligenceact.eu/annex/3/)
 - [EU AI Act Article 6 (Classification Rules)](https://artificialintelligenceact.eu/article/6/)
 - [EU AI Act Implementation Timeline](https://artificialintelligenceact.eu/implementation-timeline/)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,7 +148,7 @@ Connect to existing agent identity ecosystems for interoperability.
 |---------|-------|--------|
 | 0.1.0 | Phase 1 + 2 | Initial release (36 tools) |
 | 0.2.0 | Phase 3 | Blockchain anchoring + security audit + conformance benchmarks (47 tools, 284 tests) |
-| 0.3.0 | Phase 3.5 | Real LangChain/OpenAI Agents/CrewAI integrations, CI/CD, security hardening (358 tests) |
+| 0.3.0 | Phase 3.5 | Real LangChain/OpenAI Agents/CrewAI integrations, CI/CD, security hardening (358 tests, 1 skipped on Windows) |
 | 0.4.0 | Phase 4 | Broader GDPR coverage (beyond Article 17), ISO/IEC 42001 alignment, EAS mainnet schema registration |
 | 0.5.0 | Phase 4 | ERC-8004, A2A sync, ANS, Polygon ID / ZK credentials |
 | 0.6.0 | Phase 5 | Multi-chain + enterprise storage |

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -118,4 +118,4 @@ print(result)
 - [EU AI Act Compliance Guide](/docs/guides/eu-ai-act-compliance) - Full compliance workflow
 - [Concepts Explained](/docs/reference/concepts) - What are UAITs, DIDs, VCs?
 - [API Reference](/docs/reference/api-reference) - All 47 tools documented
-- [Integration Guide](/docs/guides/integration-guide) - LangChain, CrewAI, AutoGen integrations
+- [Integration Guide](/docs/guides/integration-guide) - LangChain, OpenAI Agents SDK, CrewAI integrations

--- a/website/content/docs/guides/architecture.mdx
+++ b/website/content/docs/guides/architecture.mdx
@@ -169,7 +169,7 @@ Attestix uses environment variables for configuration. No config files needed. S
 
 ## Testing
 
-284 tests across unit, end-to-end, and conformance benchmark suites:
+358 tests across unit, end-to-end, and conformance benchmark suites (1 skipped on Windows):
 
 ```bash
 # Run all tests

--- a/website/content/docs/guides/integration-guide.mdx
+++ b/website/content/docs/guides/integration-guide.mdx
@@ -130,7 +130,9 @@ crew = Crew(agents=[compliance_officer], tasks=[audit_task])
 result = crew.kickoff()
 ```
 
-## With AutoGen
+## With AutoGen (Example Only)
+
+> Note: AutoGen is shown here as a usage example only. It is not part of the maintained real-integration test suite. Supported real integrations are LangChain, OpenAI Agents SDK, and CrewAI.
 
 ```python
 import autogen

--- a/website/content/docs/guides/risk-classification.mdx
+++ b/website/content/docs/guides/risk-classification.mdx
@@ -134,6 +134,6 @@ If you are unsure about your risk category, consult with a legal professional sp
 ## Further Reading
 
 - [EU AI Act Full Text](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689)
-- [EU AI Act Annex III (High-Risk Categories)](https://artificialintelligenceact.eu/annex/iii/)
+- [EU AI Act Annex III (High-Risk Categories)](https://artificialintelligenceact.eu/annex/3/)
 - [EU AI Act Article 6 (Classification Rules)](https://artificialintelligenceact.eu/article/6/)
 - [EU AI Act Implementation Timeline](https://artificialintelligenceact.eu/implementation-timeline/)

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -114,7 +114,7 @@ flowchart TD
 - **Local-first** - No cloud dependency. All core operations work offline with JSON file storage
 - **Cryptographically signed** - Every artifact is signed with Ed25519. Anyone can verify without contacting Attestix
 - **Standards-based** - W3C Verifiable Credentials, W3C DIDs, UCAN delegation, A2A agent cards
-- **Vendor-neutral** - Works with any AI framework (LangChain, CrewAI, AutoGen, or plain Python)
+- **Vendor-neutral** - Works with any AI framework (LangChain, OpenAI Agents SDK, CrewAI, or plain Python)
 - **EU AI Act ready** - Risk classification, conformity assessments, Annex V declarations, Article 10/11/12 documentation
 
 ---

--- a/website/content/docs/project/contributing.mdx
+++ b/website/content/docs/project/contributing.mdx
@@ -73,7 +73,7 @@ Open an issue on GitHub with:
 3. Make your changes
 4. Run the test suite to verify nothing is broken:
    ```bash
-   # Run all 284 tests (unit, e2e, conformance benchmarks)
+   # Run all 358 tests (unit, e2e, conformance benchmarks; 1 skipped on Windows)
    pytest tests/ -v -m "not live_blockchain"
 
    # Or run in Docker for a clean environment

--- a/website/content/docs/project/research.mdx
+++ b/website/content/docs/project/research.mdx
@@ -56,7 +56,7 @@ The paper presents four main contributions:
 
 2. **Compliance automation engine** implementing Articles 5, 9-15, 43, 72-73, and Annex V of the EU AI Act, including automated risk classification, conformity assessment enforcement, and declaration generation.
 
-3. **Open-source MCP implementation** with 47 tools validated by 284 automated tests (91 conformance benchmarks against RFC 8032, W3C VC, W3C DID, and UCAN specifications).
+3. **Open-source MCP implementation** with 47 tools validated by 358 automated tests (1 skipped on Windows; 91 conformance benchmarks against RFC 8032, W3C VC, W3C DID, and UCAN specifications).
 
 4. **Tamper-evident audit mechanism** combining SHA-256 hash-chained logs with Merkle tree aggregation and on-chain anchoring via the Ethereum Attestation Service on Base L2.
 

--- a/website/content/docs/project/roadmap.mdx
+++ b/website/content/docs/project/roadmap.mdx
@@ -131,7 +131,8 @@ Connect to existing agent identity ecosystems for interoperability.
 |---------|-------|--------|
 | 0.1.0 | Phase 1 + 2 | Initial release (36 tools) |
 | 0.2.0 | Phase 3 | Blockchain anchoring + security audit + conformance benchmarks (47 tools, 284 tests) |
-| 0.3.0 | Phase 4 | ERC-8004, A2A sync, ANS |
-| 0.4.0 | Phase 4 | Polygon ID / ZK credentials |
+| 0.3.0 | Phase 3.5 | Real LangChain/OpenAI Agents/CrewAI integrations, CI/CD, security hardening (358 tests, 1 skipped on Windows) |
+| 0.4.0 | Phase 4 | ERC-8004, A2A sync, ANS |
+| 0.4.1 | Phase 4 | Polygon ID / ZK credentials |
 | 0.5.0 | Phase 5 | Multi-chain + enterprise storage |
 | 1.0.0 | Stable | Production-ready with full test suite and third-party audit |

--- a/website/content/docs/reference/configuration.mdx
+++ b/website/content/docs/reference/configuration.mdx
@@ -196,7 +196,7 @@ docker run -v attestix-data:/data attestix
 
 ### Running the Test Suite
 
-The project includes `Dockerfile.test` which runs all 284 tests (unit, e2e, and conformance benchmarks) in a clean container:
+The project includes `Dockerfile.test` which runs all 358 tests (unit, e2e, and conformance benchmarks; 1 skipped on Windows) in a clean container:
 
 ```bash
 docker build -f Dockerfile.test -t attestix-bench . && docker run --rm attestix-bench

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -11,7 +11,7 @@ Attestix provides verifiable identity, W3C credentials, delegation chains, compl
 - [Examples](https://attestix.io/docs/examples): 11 runnable code examples for all modules
 - [EU AI Act Compliance](https://attestix.io/docs/guides/eu-ai-act-compliance): Full compliance workflow with checklists
 - [Risk Classification](https://attestix.io/docs/guides/risk-classification): Decision tree for AI Act risk categories
-- [Integration Guide](https://attestix.io/docs/guides/integration-guide): LangChain, CrewAI, AutoGen, plain Python
+- [Integration Guide](https://attestix.io/docs/guides/integration-guide): LangChain, OpenAI Agents SDK, CrewAI, plain Python
 - [Architecture](https://attestix.io/docs/guides/architecture): System design, data flows, security model
 - [Reputation Scoring](https://attestix.io/docs/guides/reputation): Trust scoring, categories, recency decay
 - [API Reference](https://attestix.io/docs/reference/api-reference): All 47 tools with parameters and return types

--- a/website/src/lib/config.tsx
+++ b/website/src/lib/config.tsx
@@ -204,7 +204,7 @@ export const siteConfig = {
     {
       question: "What is the current maturity level?",
       answer:
-        `Attestix v${ATTESTIX_VERSION} is in active development (beta). It includes 284 tests across functional, end-to-end, and conformance benchmark suites covering all 9 modules. We recommend thorough testing before production deployment.`,
+        `Attestix v${ATTESTIX_VERSION} is in active development (beta). It includes 358 tests (1 skipped on Windows) across functional, end-to-end, and conformance benchmark suites covering all 9 modules. We recommend thorough testing before production deployment.`,
     },
     {
       question: "How does blockchain anchoring work?",


### PR DESCRIPTION
## Summary

Pre-YC Startup School Bengaluru (2026-04-18) documentation sweep. Closes drift caught in the 2026-04-17 link and data-accuracy audits so README, docs, website, and decks agree.

- Fixed broken links (business-card QR, Polar sponsor badge, EU AI Act Annex III anchor).
- Bumped test counts from 284 to 358 with "1 skipped on Windows" note where format allows; left v0.2.0 history row intact.
- Removed AutoGen from real-integration lists and marked the AutoGen section as Example Only. Real integrations are now consistently listed as LangChain, OpenAI Agents SDK, CrewAI (matches integrations/examples and tests/integration).
- Added a v0.3.0 row to ROADMAP.md and website/content/docs/project/roadmap.mdx.
- Added a 44-endpoint REST API reference section to docs/api-reference.md, inventoried directly from api/routers/*.py (identity 7, credentials 7, compliance 6, reputation 3, provenance 5, delegation 4, did 3, agent_cards 3, blockchain 6).

28 tracked files changed. paper/internal fixes (business card QR, SPC Sahil message, Claude Open Source application, outreach drafts, pitch verification, roadmap-2026) are gitignored but have been applied locally.

## Test plan

- [ ] Skim README.md Sponsors section (Polar badge gone)
- [ ] Visit https://attestix.io/docs/getting-started (QR destination works)
- [ ] Visit https://artificialintelligenceact.eu/annex/3/ (Annex III link works)
- [ ] Build website: `cd website && npm run build` to ensure MDX still compiles
- [ ] Visual check: docs/api-reference.md renders the new REST API tables correctly