### PR TITLE
fix(website): sync monorepo website with attestix-website main, force Cloudflare redeploy

### DIFF
--- a/website/content/docs/guides/architecture.mdx
+++ b/website/content/docs/guides/architecture.mdx
@@ -169,7 +169,7 @@ Attestix uses environment variables for configuration. No config files needed. S
 
 ## Testing
 
-358 tests across unit, end-to-end, and conformance benchmark suites (1 skipped on Windows):
+358 tests (1 skipped on Windows) across unit, end-to-end, and conformance benchmark suites:
 
 ```bash
 # Run all tests

--- a/website/content/docs/guides/eu-compliance-walkthrough.mdx
+++ b/website/content/docs/guides/eu-compliance-walkthrough.mdx
@@ -1,0 +1,14 @@
+---
+title: EU Compliance Walkthrough
+description: This guide has been renamed. See the EU AI Act Compliance guide for the full walkthrough.
+---
+
+# EU Compliance Walkthrough
+
+This page has moved. The full walkthrough now lives at the [EU AI Act Compliance guide](/docs/guides/eu-ai-act-compliance).
+
+For related material, see:
+
+- [Risk Classification Guide](/docs/guides/risk-classification)
+- [Architecture Overview](/docs/guides/architecture)
+- [Integration Guide](/docs/guides/integration-guide)

--- a/website/content/docs/project/changelog.mdx
+++ b/website/content/docs/project/changelog.mdx
@@ -9,6 +9,42 @@ All notable changes to Attestix are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] - 2026-04-17
+
+Flagship release introducing real framework integrations, a security hardening sweep, and GitHub Actions CI/CD.
+
+### Added
+
+**Real framework integrations (not simulations)**
+- LangChain integration via `BaseCallbackHandler` that logs every tool call, LLM call, and chain step to the Attestix audit trail with hash chaining (#42)
+- OpenAI Agents SDK integration using `MCPServerStdio` so agents can call Attestix tools directly as MCP tools (#48)
+- CrewAI integration that attaches Attestix to the `mcps` field on every agent, giving each crew member full attestation capabilities (#51)
+- 7 additional framework integration examples and 15 integration tests covering LangChain, OpenAI Agents SDK, and CrewAI end to end (#41)
+
+**CI/CD and release tooling**
+- GitHub Actions workflow with pytest matrix (Linux and Windows), lint, and security scan jobs (#49)
+- Single-job PyPI publish workflow restored to token auth (#54, #56)
+- Automated release for v0.3.0 including tag, PyPI push, and documentation sync (#52, #58)
+
+**Security fixes (HIGH severity)**
+- SSRF redirect following hardened to re-check every redirect target against the private IP and metadata endpoint allow list (#47)
+- API key comparison moved to constant-time HMAC to prevent timing side channels (#47)
+- Exception messages sanitized so internal file paths and stack traces no longer leak to MCP clients (#47)
+- `display_name` validation tightened to block control characters and oversized values (#47)
+- Signing key file permissions locked down to owner-only read/write on POSIX (#47)
+- Delegation chain authentication bypass fixed: parent tokens are now fully verified and capability attenuation is enforced so a delegatee cannot silently escalate privileges beyond its delegator (#45)
+- PyJWT CVE remediated, plus simplified publish workflow removed the id-token and environment gate that blocked v0.3.0 publishing (#55)
+
+**Correctness fixes**
+- EAS schema UID derivation corrected and on-chain event decoding hardened so `anchor_credential` and `verify_anchor` no longer misreport status (#50)
+- Article 43 conformity assessment now differentiates Annex III categories per the EU AI Act text, so self-assessment is permitted where the regulation allows and blocked where it does not (#46)
+- Persona e2e test findings addressed: version printout, `python -m attestix`, and quickstart path fixed (#57)
+
+### Changed
+
+- Total automated tests: 284 -> 358 (267 functional + 91 conformance benchmarks), 1 skipped on Windows
+- Documentation refreshed to reflect v0.3.0 current state: 358 tests, 3 real framework integrations, CI/CD pipeline (#58)
+
 ## [0.2.4] - 2026-03-10
 
 ### Added
@@ -75,7 +111,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - FAQ entry on standards validation methodology
 
 ### Changed
-- Total automated tests: 193 -> 284 (193 functional + 91 conformance benchmarks)
+- Total automated tests: 193 -> 284 (193 functional + 91 conformance benchmarks). See the 0.3.0 entry for the current figure (358).
 - Updated research paper evaluation section with conformance test results and measured latencies
 - Updated all documentation (architecture, changelog, contributing, roadmap, FAQ) with benchmark details
 
@@ -103,7 +139,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `verify_presentation` - Verify Verifiable Presentations with embedded credentials
 
 **Testing**
-- 284 automated tests (unit, integration, e2e, conformance benchmarks)
+- 284 automated tests at the 0.2.0 cut (unit, integration, e2e, conformance benchmarks). The current figure is 358 (see 0.3.0).
 - 91 conformance benchmark tests validating standards compliance:
   - RFC 8032 Section 7.1 Ed25519 canonical test vectors (4 IETF vectors, 18 tests)
   - W3C VC Data Model 1.1 conformance (credential structure, proof, presentations, 24 tests)

--- a/website/content/docs/project/research.mdx
+++ b/website/content/docs/project/research.mdx
@@ -13,7 +13,7 @@ Attestix is described in a peer-reviewed research paper that covers the system a
 
 Pavan Kumar Dubasi (VibeTensor Private Limited)
 
-> The rapid proliferation of autonomous AI agents operating across organizational boundaries introduces fundamental challenges in identity verification, trust establishment, and regulatory compliance. We present Attestix, an open-source attestation infrastructure that provides a unified trust layer for AI agents through nine integrated modules. Attestix is implemented as a Model Context Protocol (MCP) server exposing 47 tools, validated by 284 automated tests including 91 conformance benchmarks against RFC 8032, W3C VC/DID, and UCAN specifications.
+> The rapid proliferation of autonomous AI agents operating across organizational boundaries introduces fundamental challenges in identity verification, trust establishment, and regulatory compliance. We present Attestix, an open-source attestation infrastructure that provides a unified trust layer for AI agents through nine integrated modules. Attestix is implemented as a Model Context Protocol (MCP) server exposing 47 tools, validated by 358 automated tests including 91 conformance benchmarks against RFC 8032, W3C VC/DID, and UCAN specifications, plus real integrations with LangChain, OpenAI Agents SDK, and CrewAI.
 
 **Links:**
 
@@ -56,7 +56,7 @@ The paper presents four main contributions:
 
 2. **Compliance automation engine** implementing Articles 5, 9-15, 43, 72-73, and Annex V of the EU AI Act, including automated risk classification, conformity assessment enforcement, and declaration generation.
 
-3. **Open-source MCP implementation** with 47 tools validated by 358 automated tests (1 skipped on Windows; 91 conformance benchmarks against RFC 8032, W3C VC, W3C DID, and UCAN specifications).
+3. **Open-source MCP implementation** with 47 tools validated by 358 automated tests (91 conformance benchmarks against RFC 8032, W3C VC, W3C DID, and UCAN specifications, plus real integrations with LangChain, OpenAI Agents SDK, and CrewAI).
 
 4. **Tamper-evident audit mechanism** combining SHA-256 hash-chained logs with Merkle tree aggregation and on-chain anchoring via the Ethereum Attestation Service on Base L2.
 

--- a/website/content/docs/project/roadmap.mdx
+++ b/website/content/docs/project/roadmap.mdx
@@ -131,8 +131,7 @@ Connect to existing agent identity ecosystems for interoperability.
 |---------|-------|--------|
 | 0.1.0 | Phase 1 + 2 | Initial release (36 tools) |
 | 0.2.0 | Phase 3 | Blockchain anchoring + security audit + conformance benchmarks (47 tools, 284 tests) |
-| 0.3.0 | Phase 3.5 | Real LangChain/OpenAI Agents/CrewAI integrations, CI/CD, security hardening (358 tests, 1 skipped on Windows) |
-| 0.4.0 | Phase 4 | ERC-8004, A2A sync, ANS |
-| 0.4.1 | Phase 4 | Polygon ID / ZK credentials |
+| 0.3.0 | Phase 3 hardening | Real framework integrations (LangChain, OpenAI Agents SDK, CrewAI), security hardening, 358 tests, GitHub Actions CI/CD |
+| 0.4.0 | Phase 4 | ERC-8004, A2A sync, ANS, Polygon ID / ZK credentials |
 | 0.5.0 | Phase 5 | Multi-chain + enterprise storage |
 | 1.0.0 | Stable | Production-ready with full test suite and third-party audit |

--- a/website/content/docs/reference/configuration.mdx
+++ b/website/content/docs/reference/configuration.mdx
@@ -196,7 +196,7 @@ docker run -v attestix-data:/data attestix
 
 ### Running the Test Suite
 
-The project includes `Dockerfile.test` which runs all 358 tests (unit, e2e, and conformance benchmarks; 1 skipped on Windows) in a clean container:
+The project includes `Dockerfile.test` which runs all 358 tests (1 skipped on Windows) across unit, e2e, and conformance benchmarks in a clean container:
 
 ```bash
 docker build -f Dockerfile.test -t attestix-bench . && docker run --rm attestix-bench
@@ -204,6 +204,6 @@ docker build -f Dockerfile.test -t attestix-bench . && docker run --rm attestix-
 
 This validates:
 
-- 193 unit and end-to-end tests
+- 267 unit and end-to-end tests (functional, framework integrations, security)
 - 91 conformance benchmarks (RFC 8032, W3C VC, W3C DID, UCAN, MCP, performance)
 - Performance thresholds for all cryptographic and service operations

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attestix-website",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/website/public/demo.cast.README.md
+++ b/website/public/demo.cast.README.md
@@ -1,0 +1,44 @@
+# Attestix Demo Recording
+
+Two options are checked in here so whoever ships the demo can pick the path that works on their machine.
+
+## Option A: VHS (recommended, produces a GIF)
+
+VHS is a scripted terminal recorder from Charmbracelet. The tape file at `public/demo.tape` scripts the entire pip install and CLI walkthrough. Render with:
+
+```bash
+vhs public/demo.tape
+```
+
+This writes `public/demo.gif`. Commit the GIF so it is served from the static export.
+
+Install VHS:
+
+- macOS: `brew install vhs`
+- Linux: `go install github.com/charmbracelet/vhs@latest`
+- Windows: `scoop install vhs` (or run inside WSL)
+
+## Option B: asciinema (produces a .cast file)
+
+If VHS is unavailable, record a terminal session directly:
+
+```bash
+asciinema rec public/demo.cast \
+  --title "Attestix Quick Start" \
+  --idle-time-limit 2
+```
+
+Run these commands inside the recording so viewers see the real output:
+
+```bash
+pip install attestix
+attestix init
+attestix status
+attestix verify ./credentials/agent-card.vc.json
+```
+
+Stop the recording with `Ctrl+D`. To embed the `.cast` file on the site, drop the asciinema web player script in the page that hosts the hero.
+
+## Where the media is used
+
+The hero section at `src/components/sections/hero.tsx` expects a media asset. After generating either `public/demo.gif` or converting the asciinema cast to a GIF, update the hero to reference `/demo.gif`.

--- a/website/public/demo.tape
+++ b/website/public/demo.tape
@@ -1,0 +1,63 @@
+# Attestix Quick Start Demo (VHS tape file)
+#
+# Render with:
+#   vhs public/demo.tape
+#
+# Installs: https://github.com/charmbracelet/vhs
+#   - macOS:  brew install vhs
+#   - Linux:  go install github.com/charmbracelet/vhs@latest
+#   - Windows (WSL or Scoop):  scoop install vhs
+#
+# Output will be written to public/demo.gif (referenced by hero section).
+# After regenerating, commit the GIF so it ships with the static export.
+
+Output public/demo.gif
+
+Set FontSize 18
+Set Width 1200
+Set Height 720
+Set Padding 24
+Set Theme "Dracula"
+Set TypingSpeed 45ms
+Set PlaybackSpeed 1.0
+
+# Fake a fresh shell prompt
+Type "# Install Attestix from PyPI"
+Enter
+Sleep 400ms
+
+Type "pip install attestix"
+Enter
+Sleep 1500ms
+
+Type "clear"
+Enter
+Sleep 300ms
+
+Type "# Initialize a compliance workspace"
+Enter
+Sleep 400ms
+
+Type "attestix init"
+Enter
+Sleep 1500ms
+
+Type "# Check workspace status"
+Enter
+Sleep 400ms
+
+Type "attestix status"
+Enter
+Sleep 1500ms
+
+Type "# Verify a credential"
+Enter
+Sleep 400ms
+
+Type "attestix verify ./credentials/agent-card.vc.json"
+Enter
+Sleep 2000ms
+
+Type "# Every action is cryptographically signed and auditable."
+Enter
+Sleep 2000ms

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -1,8 +1,25 @@
 import { getBlogPosts } from "@/lib/blog";
 import { siteConfig } from "@/lib/config";
+import { source } from "@/lib/source";
 import { MetadataRoute } from "next";
 
 export const dynamic = "force-static";
+
+// Per-section priority weighting for generated docs routes.
+const docsPriority: Record<string, number> = {
+  "getting-started": 0.9,
+  examples: 0.75,
+  guides: 0.8,
+  reference: 0.8,
+  project: 0.6,
+};
+
+function docsPriorityFor(slug: readonly string[]): number {
+  if (slug.length === 0) {
+    return 0.9;
+  }
+  return docsPriority[slug[0]] ?? 0.7;
+}
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await getBlogPosts();
@@ -13,6 +30,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     changeFrequency: "monthly" as const,
     priority: 0.6,
   }));
+
+  // Auto-generate routes for every docs MDX page so the sitemap stays in sync
+  // with `content/docs/**` instead of being manually hand-maintained (which
+  // previously surfaced only 4 of 17+ pages to crawlers). The `/docs` index is
+  // listed above as a hardcoded high-priority entry, so skip any empty-slug
+  // page here to avoid emitting a duplicate <url> for the same loc.
+  const docsRoutes = source
+    .getPages()
+    .filter((page) => page.slugs.length > 0)
+    .map((page) => ({
+      url: `${siteConfig.url}${page.url}`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: docsPriorityFor(page.slugs),
+    }));
 
   return [
     {
@@ -69,30 +101,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.9,
     },
-    {
-      url: `${siteConfig.url}/docs/getting-started`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${siteConfig.url}/docs/examples`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${siteConfig.url}/docs/guides/eu-ai-act-compliance`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${siteConfig.url}/docs/reference/api-reference`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
+    ...docsRoutes,
     {
       url: `${siteConfig.url}/cross-post`,
       lastModified: new Date(),

--- a/website/src/components/sections/statistics.tsx
+++ b/website/src/components/sections/statistics.tsx
@@ -12,13 +12,15 @@ import Link from "next/link";
 const stats = [
   {
     value: 47,
+    startValue: 37,
     suffix: "",
     subtitle: "MCP Tools across 9 modules",
     icon: <WrenchIcon className="h-5 w-5" />,
     href: "/docs",
   },
   {
-    value: 284,
+    value: 358,
+    startValue: 340,
     suffix: "",
     subtitle: "Tests with conformance benchmarks",
     icon: <FlaskConicalIcon className="h-5 w-5" />,
@@ -26,6 +28,7 @@ const stats = [
   },
   {
     value: 6,
+    startValue: 1,
     suffix: "",
     subtitle: "Conformance test suites (W3C, IETF, UCAN, MCP)",
     icon: <BookOpenIcon className="h-5 w-5" />,
@@ -72,6 +75,7 @@ export function Statistics() {
                 <div className="flex items-center justify-center">
                   <NumberTicker
                     value={stat.value}
+                    startValue={stat.startValue}
                     className="font-mono pointer-events-none text-center text-[6rem] font-bold leading-none before:bg-gradient-to-b before:from-border before:to-border/50 dark:before:from-border dark:before:to-border/30 bg-gradient-to-b from-foreground/60 to-foreground/30 bg-clip-text text-transparent"
                   />
                 </div>

--- a/website/src/components/sections/tech-stack.tsx
+++ b/website/src/components/sections/tech-stack.tsx
@@ -23,6 +23,9 @@ import {
   WindIcon,
   TerminalIcon,
   BookOpenIcon,
+  BrainIcon,
+  SparklesIcon,
+  UsersIcon,
 } from "lucide-react";
 
 interface TechItem {
@@ -49,6 +52,15 @@ const categories: { title: string; description: string; items: TechItem[] }[] = 
       { name: "JWT", label: "JSON Web Tokens", Icon: LockIcon, color: "gold" },
       { name: "DID:key", label: "DID Key Method", Icon: FileSearchIcon, color: "primary" },
       { name: "EAS", label: "Ethereum Attestation Service", Icon: HashIcon, color: "gold" },
+    ],
+  },
+  {
+    title: "Agent Frameworks",
+    description: "Real, shipped integrations in v0.3.0 (not simulations)",
+    items: [
+      { name: "LangChain", label: "LangChain via BaseCallbackHandler", Icon: BrainIcon, color: "primary" },
+      { name: "OpenAI Agents", label: "OpenAI Agents SDK via MCPServerStdio", Icon: SparklesIcon, color: "primary" },
+      { name: "CrewAI", label: "CrewAI via mcps field on every agent", Icon: UsersIcon, color: "primary" },
     ],
   },
   {

--- a/website/src/components/sections/testimonials.tsx
+++ b/website/src/components/sections/testimonials.tsx
@@ -193,21 +193,7 @@ export function Testimonials() {
         description="Researchers, founders, and industry leaders validating the need for verifiable trust infrastructure in AI agent systems."
       >
         <div className="relative border-x border-b overflow-hidden py-8">
-          <Marquee pauseOnHover className="[--duration:35s] [--gap:1rem]">
-            {highlights.map((highlight) => (
-              <TestimonialCard
-                key={highlight.id}
-                highlight={highlight}
-                onClick={() => setSelectedHighlight(highlight)}
-              />
-            ))}
-          </Marquee>
-
-          <Marquee
-            pauseOnHover
-            reverse
-            className="mt-4 [--duration:40s] [--gap:1rem]"
-          >
+          <Marquee pauseOnHover repeat={2} className="[--duration:45s] [--gap:1rem]">
             {highlights.map((highlight) => (
               <TestimonialCard
                 key={highlight.id}

--- a/website/src/components/ui/number-ticker.tsx
+++ b/website/src/components/ui/number-ticker.tsx
@@ -23,6 +23,10 @@ export function NumberTicker({
   ...props
 }: NumberTickerProps) {
   const ref = useRef<HTMLSpanElement>(null)
+  // Start at the start value on the client so the count-up animation is
+  // visible. SSR/no-JS renders a static text node with the final value (see
+  // `initialText` below), so crawlers and social previews still see the real
+  // numbers even if hydration never completes.
   const motionValue = useMotionValue(direction === "down" ? value : startValue)
   const springValue = useSpring(motionValue, {
     damping: 60,
@@ -52,6 +56,13 @@ export function NumberTicker({
     [springValue, decimalPlaces]
   )
 
+  // SSR / initial render shows the target value so crawlers and no-JS visitors
+  // see "47", "358", "6" rather than "0" or a start value.
+  const initialText = Intl.NumberFormat("en-US", {
+    minimumFractionDigits: decimalPlaces,
+    maximumFractionDigits: decimalPlaces,
+  }).format(Number(value.toFixed(decimalPlaces)))
+
   return (
     <span
       ref={ref}
@@ -61,7 +72,7 @@ export function NumberTicker({
       )}
       {...props}
     >
-      {startValue}
+      {initialText}
     </span>
   )
 }

--- a/website/src/lib/config.tsx
+++ b/website/src/lib/config.tsx
@@ -3,7 +3,7 @@ import { Icons } from "@/components/icons";
 export const BLUR_FADE_DELAY = 0.15;
 
 export const ATTESTIX_VERSION =
-  process.env.NEXT_PUBLIC_ATTESTIX_VERSION || "0.2.4";
+  process.env.NEXT_PUBLIC_ATTESTIX_VERSION || "0.3.0";
 
 export const siteConfig = {
   name: "Attestix",
@@ -33,9 +33,9 @@ export const siteConfig = {
   hero: {
     title: "Attestix",
     description:
-      "The EU AI Act takes effect August 2, 2026. Non-compliant organizations face fines up to EUR 35 million or 7% of global revenue. Attestix is like TurboTax for AI compliance: it automates the documentation, identity verification, and audit trails your AI agents need to stay legal. Install once, generate cryptographic proof of compliance on every run.",
+      "The EU AI Act takes effect August 2, 2026. Non-compliant organizations face fines up to EUR 35 million or 7% of global revenue. Attestix is like TurboTax for AI compliance: it automates the documentation, identity verification, and audit trails your AI agents need to stay legal. Install once, drop into LangChain, OpenAI Agents SDK, or CrewAI, and generate cryptographic proof of compliance on every run.",
     cta: "pip install attestix",
-    ctaDescription: "Open source. Apache 2.0 license.",
+    ctaDescription: "v0.3.0 - 358 tests passing. Real LangChain, OpenAI Agents SDK, and CrewAI integrations. Apache 2.0 license.",
   },
   pricing: [
     {
@@ -124,49 +124,49 @@ export const siteConfig = {
 
   highlights: [
     {
-      id: 4,
-      text: "How do we design where we can have trust? This is one of the very active conversations that we are having right now.",
-      name: "Julie Zhuo",
-      role: "Founder, Sundial",
-      company: "Ex-VP Product Design, Meta (14 years)",
+      id: 1,
+      text: "I encourage you to continue with your project.",
+      name: "Yoshua Bengio",
+      role: "Turing Award Laureate",
+      company: "Scientific Director, MILA",
 
       validation: "problem" as const,
-      context: "On trust infrastructure for AI agent workflows",
+      context: "Direct encouragement on the Attestix mission",
       askedBy: "Pavan Kumar Dubasi",
-      question: "As AI agents start making autonomous decisions, who is responsible when an agent makes a bad data-driven decision? How does Sundial think about the trust and accountability layer for agent workflows? Should AI agents have verifiable proof of work before they can act?",
-      event: "Fireside Chat with Julie Zhuo | South Park Commons",
-      venue: "SPC India, HSR Layout, Bengaluru - March 3, 2026",
-      detail: "Julie confirmed that designing trust for AI agents is an active, unsolved problem at Sundial. She described the management chain model where a human somewhere in the chain owns accountability. This maps directly to Attestix's UCAN delegation chains, where every agent action traces back to a human principal through cryptographic proof of authorization.",
+      question: "Shared the Attestix mission and verifiable trust infrastructure approach for AI agents under the EU AI Act.",
+      event: "Email Correspondence",
+      venue: "February 21, 2026",
+      detail: "Professor Bengio, one of the three Turing Award recipients for deep learning and a leading voice in AI safety, reviewed the Attestix pitch and replied with direct encouragement. His endorsement underscores the importance of building verifiable, open source trust infrastructure for autonomous AI agents.",
     },
     {
-      id: 5,
-      text: "How do humans trust each other? Benefit of the doubt, then validate work, then trust more. We build structures to minimise mistakes given the context.",
-      name: "Julie Zhuo",
-      role: "Founder, Sundial",
-      company: "Ex-VP Product Design, Meta (14 years)",
+      id: 2,
+      text: "The fact you are open source is really interesting.",
+      name: "Alvaro Cabrejas Egea",
+      role: "AI Policy Officer",
+      company: "EU AI Office, European Commission",
 
       validation: "problem" as const,
-      context: "Describing progressive trust, the pattern Attestix implements",
+      context: "On the value of open source compliance tooling for the EU AI Act",
       askedBy: "Pavan Kumar Dubasi",
-      question: "As AI agents start making autonomous decisions, who is responsible when an agent makes a bad data-driven decision? How does Sundial think about the trust and accountability layer for agent workflows? Should AI agents have verifiable proof of work before they can act?",
-      event: "Fireside Chat with Julie Zhuo | South Park Commons",
-      venue: "SPC India, HSR Layout, Bengaluru - March 3, 2026",
-      detail: "Julie described how humans build trust progressively: start with benefit of the doubt, validate work, then extend more trust. This is exactly the pattern Attestix's reputation scoring module implements. Agents earn trust scores based on verified actions, compliance history, and audit trail integrity. Progressive trust, but cryptographically verifiable.",
+      question: "Walked through how Attestix produces cryptographically verifiable evidence for EU AI Act Articles 16 to 22 while the provider remains legally liable.",
+      event: "Direct Discussion on EU AI Act Enforcement",
+      venue: "European Commission Outreach - 2026",
+      detail: "Alvaro raised the critical liability question of who is responsible when a deployed system is found non compliant. The answer is that providers remain liable under Articles 16 to 22. Attestix is positioned as the evidence generation tool, not a guarantor. Alvaro expressed genuine interest in the open source angle and said he would share the approach with the appropriate team.",
     },
     {
-      id: 6,
-      text: "Code reviews as a process to generate trust. That is how trust is created, because humans are not perfect. We always need structured verification.",
-      name: "Julie Zhuo",
-      role: "Founder, Sundial",
-      company: "Ex-VP Product Design, Meta (14 years)",
+      id: 3,
+      text: "I can see how to put a register of compliance and self certify or get a third party certifier to cryptographically sign.",
+      name: "Matt Pagett",
+      role: "AI Safety Researcher",
+      company: "CBAAC Author, NANDA Contributor",
 
       validation: "problem" as const,
-      context: "Structured verification for AI agents is what Attestix automates",
+      context: "Describing the exact primitives Attestix already ships",
       askedBy: "Pavan Kumar Dubasi",
-      question: "As AI agents start making autonomous decisions, who is responsible when an agent makes a bad data-driven decision? How does Sundial think about the trust and accountability layer for agent workflows? Should AI agents have verifiable proof of work before they can act?",
-      event: "Fireside Chat with Julie Zhuo | South Park Commons",
-      venue: "SPC India, HSR Layout, Bengaluru - March 3, 2026",
-      detail: "Julie sees code reviews as the human model for trust generation: structured review processes that catch mistakes before they ship. Attestix automates this exact pattern for AI agents. Instead of code reviews, agents undergo compliance verification, identity attestation, and authorization checks before they can act. Structured verification, but automated and cryptographically signed.",
+      question: "Walked through the Attestix automated compliance attestation flow: UAIT identity, compliance profile, training data records, model lineage, audit trail, Annex V declaration, and auto issued W3C Verifiable Credentials.",
+      event: "1 on 1 Discovery Call",
+      venue: "Remote - February 27, 2026",
+      detail: "Matt framed Attestix as TurboTax for AI compliance: layers of audit protection chosen by risk exposure and budget, with the company still owning final responsibility. He validated the business case, signaled strong alignment with CBAAC and NANDA, and agreed to re engage once he moves to Munich in April or May 2026 to connect Attestix with European compliance buyers.",
     },
   ],
 
@@ -204,7 +204,12 @@ export const siteConfig = {
     {
       question: "What is the current maturity level?",
       answer:
-        `Attestix v${ATTESTIX_VERSION} is in active development (beta). It includes 358 tests (1 skipped on Windows) across functional, end-to-end, and conformance benchmark suites covering all 9 modules. We recommend thorough testing before production deployment.`,
+        `Attestix v${ATTESTIX_VERSION} is in active development (beta). It includes 358 tests across functional, end-to-end, and conformance benchmark suites covering all 9 modules, plus real integrations with LangChain, OpenAI Agents SDK, and CrewAI. GitHub Actions CI runs the full pytest matrix, lint, and security scans on every push. We still recommend thorough testing before production deployment.`,
+    },
+    {
+      question: "Does Attestix work with LangChain, OpenAI Agents SDK, or CrewAI?",
+      answer:
+        "Yes, all three are real integrations shipped in v0.3.0 rather than examples or shims. LangChain uses a BaseCallbackHandler that writes every tool call, LLM call, and chain step to the Attestix audit trail with hash chaining. OpenAI Agents SDK uses MCPServerStdio so Attestix tools appear as native MCP tools. CrewAI attaches Attestix to the mcps field on every agent, giving each crew member full attestation capabilities. You can also use Attestix via its MCP server from any MCP-compatible client (Claude Desktop, Cursor, Continue, Windsurf, VS Code).",
     },
     {
       question: "How does blockchain anchoring work?",


### PR DESCRIPTION
## Summary

- Cloudflare Pages is wired to this monorepo's website/ subdirectory, not the split-out VibeTensor/attestix-website repo. PRs #1 and #2 on attestix-website never shipped to attestix.io because of this.
- Replay both PRs here so the live site actually updates before the YC Bengaluru demo.
- Content: kill 16x Julie Zhuo testimonial loop, NumberTicker SSR fix, LangChain/OpenAI Agents SDK/CrewAI story on landing, 284 to 358 everywhere, full v0.3.0 changelog entry, auto-generated docs sitemap (14 to 32 URLs).
- Followup: once this deploys, rewire Cloudflare Pages to the dedicated attestix-website repo and remove this directory from the monorepo.

## Test plan

- [x] `npm run build` succeeds (46 static pages exported, same as attestix-website).
- [x] Built `out/index.html` contains LangChain, OpenAI Agents, CrewAI, and the stats 47, 358, 6 in the SSR markup (not 0/0/0).
- [x] Built `out/index.html` contains zero Julie Zhuo mentions.
- [x] Built `out/sitemap.xml` now lists 32 URLs.
- [x] Built `out/docs/guides/eu-compliance-walkthrough.html` exists.
- [ ] After merge, Cloudflare Pages redeploys and https://attestix.io/ flips to the new content within 5 minutes.
- [ ] https://attestix.io/docs/guides/eu-compliance-walkthrough returns 200 not 404.