### PR TITLE
fix(ci): repair Security + SBOM workflows and harden the Actions supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # GitHub Actions: keep the SHA-pinned actions current (Dependabot bumps the
+  # SHA and the trailing version comment together).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Python package dependencies (pyproject.toml / requirements.txt at the root).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "python"
+
+  # Marketing website + docs (Next.js) npm dependencies.
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "javascript"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -41,7 +41,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -25,7 +25,7 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: sbom-${{ github.ref }}
@@ -18,12 +18,16 @@ jobs:
   cyclonedx:
     name: Generate CycloneDX SBOM
     runs-on: ubuntu-latest
+    # contents: write is required to upload the SBOM as a release asset via
+    # the gh CLI when this workflow runs on a published release.
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -49,7 +53,7 @@ jobs:
           cat attestix-sbom.cyclonedx.json.sha256
 
       - name: Upload SBOM as workflow artefact (30-day retention)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: attestix-sbom-cyclonedx
           path: |
@@ -59,10 +63,10 @@ jobs:
 
       - name: Attach SBOM to the GitHub release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            attestix-sbom.cyclonedx.json
-            attestix-sbom.cyclonedx.json.sha256
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            attestix-sbom.cyclonedx.json \
+            attestix-sbom.cyclonedx.json.sha256 \
+            --clobber

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,54 @@
+name: OpenSSF Scorecard
+
+on:
+  # Re-run whenever a branch protection rule changes (recommended by the action).
+  branch_protection_rule:
+  # Weekly: every Monday at 07:00 UTC.
+  schedule:
+    - cron: '0 7 * * 1'
+  push:
+    branches: [main]
+
+# Top-level token is read-only; the job elevates only what it needs.
+permissions:
+  contents: read
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (OIDC token).
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the OpenSSF REST API for the Scorecard badge.
+          publish_results: true
+
+      - name: Upload artifact (SARIF)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -40,11 +40,13 @@ jobs:
 
       - name: Run pip-audit
         # Advisory on PR, enforced on schedule + push to main.
+        # --skip-editable avoids auditing the locally-installed editable
+        # package itself (which is not resolvable on PyPI before release).
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pip-audit --progress-spinner off || echo "pip-audit findings present (advisory on PR)."
+            pip-audit --progress-spinner off --skip-editable || echo "pip-audit findings present (advisory on PR)."
           else
-            pip-audit --progress-spinner off --strict
+            pip-audit --progress-spinner off --skip-editable --strict
           fi
 
   bandit:
@@ -52,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -75,10 +77,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: ./coverage.xml
           flags: unittests
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-xml
           path: coverage.xml


### PR DESCRIPTION
## Summary

Repairs the two failing CI workflows and hardens the GitHub Actions supply chain across all workflows. No functional/runtime code changed; CI/CD config only.

## Fixes

### 1. Security workflow (`security.yml`) — `pip-audit` failure
The `pip-audit --strict` step failed with `attestix: Dependency not found on PyPI and could not be audited: attestix (0.4.0rc1)` because it was auditing the locally-installed **editable** package itself (not yet on PyPI). Added `--skip-editable` to **both** `pip-audit` invocations (the advisory PR run and the `--strict` push/schedule run). `--strict` is preserved for non-PR runs.

### 2. SBOM workflow (`sbom.yml`) — `startup_failure`
The release-attachment step used the third-party `softprops/action-gh-release@v2`, which was blocked by the repo action-allowlist at workflow startup. Replaced it with a `gh release upload "<tag>" ... --clobber` `run:` step, guarded by `if: github.event_name == 'release'` and authenticated via `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`. Also moved `permissions: contents: write` off the top level (now `contents: read`) and scoped it to the `cyclonedx` job, which is the only thing that needs to write release assets.

## Hardening

### 3. SHA-pinned every action
All actions are pinned to a full 40-char commit SHA with a trailing `# vX.Y.Z` comment (pinned to the latest patch within each currently-used major to harden without forcing risky major-version upgrades):

| Action | Pin |
|---|---|
| actions/checkout | `34e114876b0b11c390a56381ad16ebd13914f8d5` # v4.3.1 |
| actions/setup-python | `a26af69be951a213d495a4c3e4e4022e16d87065` # v5.6.0 |
| actions/upload-artifact | `ea165f8d65b6e75b540449e92b4886f43607fa02` # v4.6.2 |
| codecov/codecov-action | `75cd11691c0faa626561e295848008c8a7dddffe` # v5.5.4 |
| cloudflare/wrangler-action | `9acf94ace14e7dc412b076f2c5c20b8ce93c79cd` # v3.15.0 |
| pypa/gh-action-pypi-publish | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` # v1.14.0 |
| ossf/scorecard-action | `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` # v2.4.3 |
| github/codeql-action/upload-sarif | `03e4368ac7daa2bd82b3e85262f3bf87ee112f57` # v3.36.0 |

### 4. Least-privilege permissions
Every workflow keeps a top-level `permissions: contents: read`; elevation is per-job only where required (`sbom.yml` cyclonedx job: `contents: write`; `scorecard.yml` analysis job: `security-events: write` + `id-token: write` + `contents: read`).

### 5. Dependabot (`.github/dependabot.yml`)
Added weekly, grouped updates for three ecosystems: `github-actions` (`/`), `pip` (`/`), and `npm` (`/website`). No prior dependabot config existed.

### 6. OpenSSF Scorecard (`.github/workflows/scorecard.yml`)
New SHA-pinned Scorecard workflow triggering on `branch_protection_rule`, a weekly cron, and push to `main`. Job-scoped least-privilege permissions; uploads SARIF to code scanning via `github/codeql-action/upload-sarif`.

## Publishing unchanged
`publish.yml` is SHA-pinned only. `password: ${{ secrets.PYPI_API_TOKEN }}` is **kept exactly as-is** — this PR intentionally does **not** switch to OIDC/Trusted Publishing, which would break publishing until a Trusted Publisher is configured on PyPI.

## Maintainer follow-up: migrate to PyPI Trusted Publishing (later PR)
When ready, migrate `publish.yml` to OIDC Trusted Publishing + PEP 740 attestations:

1. On https://pypi.org → project `attestix` → **Settings → Publishing → Add a pending/Trusted Publisher**, with:
   - Owner: `VibeTensor`, Repository: `attestix`
   - Workflow filename: `publish.yml`
   - Environment name: `pypi`
2. In `publish.yml`, in the `publish` job:
   - Add `environment: pypi`
   - Add job-scoped `permissions:` with `id-token: write` (keep `contents: read`)
   - **Delete** the `password: ${{ secrets.PYPI_API_TOKEN }}` line entirely (OIDC needs no password).
   - Keep `skip-existing: true` / `verbose: true` as desired; attestations (PEP 740) are emitted by default when publishing via OIDC.
3. After verifying a successful OIDC publish, delete the now-unused `PYPI_API_TOKEN` repo secret.

## Validation
- `actionlint` v1.7.12 run against all 7 workflows: **exit 0, no findings**.
- `python -c "import yaml; ..."` parsed every workflow + `dependabot.yml` successfully.

## Test plan
- Merge → SBOM workflow's `push` trigger runs and completes (no startup_failure).
- Open any PR → Security workflow `pip-audit` step no longer errors on the editable `attestix` package.
- On the next published release → SBOM is attached to the release via gh CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated weekly dependency updates across GitHub Actions, Python, and npm ecosystems.
  * Added OpenSSF Scorecard security analysis workflow running weekly and on code changes.
  * Enhanced CI/CD workflow security by pinning GitHub Actions to specific commit versions.
  * Updated SBOM release asset upload mechanism with improved permissions handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VibeTensor/attestix/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->