### PR TITLE
docs: rc2 — adopt canonical `attestix.*` namespace across all docs + migration guide

### DIFF
--- a/website/content/docs/examples.mdx
+++ b/website/content/docs/examples.mdx
@@ -5,12 +5,16 @@ description: Runnable examples for every Attestix module, from identity creation
 
 # Examples
 
-Runnable examples for every Attestix module. All examples work standalone after `pip install attestix`.
+Runnable examples for every Attestix module. All examples work standalone after `pip install --pre attestix` (v0.4.0-rc.2 release candidate) or `pip install attestix` (stable 0.3.0).
+
+v0.4.0-rc.2 ships the canonical `attestix.*` namespace shown below. The pre-rc.2
+flat layout (`from services... import`) still works as a deprecation shim but is
+scheduled for removal in v0.5.0. See the [namespace migration guide](/docs/guides/migration-v0.4.0-namespace).
 
 ## 1. Create and Verify an Agent Identity
 
 ```python
-from services.identity_service import IdentityService
+from attestix.services.identity_service import IdentityService
 
 svc = IdentityService()
 
@@ -44,7 +48,7 @@ print(f"Checks: {result['checks']}")
 Convert any Attestix identity to a Google A2A-compatible Agent Card for interoperability:
 
 ```python
-from services.identity_service import IdentityService
+from attestix.services.identity_service import IdentityService
 
 svc = IdentityService()
 
@@ -74,7 +78,7 @@ print(claims["scope"])    # customer_support order_tracking faq
 ## 3. Create DIDs
 
 ```python
-from services.did_service import DIDService
+from attestix.services.did_service import DIDService
 
 svc = DIDService()
 
@@ -103,8 +107,8 @@ print(f"Verification methods: {len(doc['verificationMethod'])}")
 Delegate capabilities from one agent to another with verifiable authority chains:
 
 ```python
-from services.identity_service import IdentityService
-from services.delegation_service import DelegationService
+from attestix.services.identity_service import IdentityService
+from attestix.services.delegation_service import DelegationService
 
 identity_svc = IdentityService()
 delegation_svc = DelegationService()
@@ -169,10 +173,10 @@ print(f"Analyst's delegations: {len(delegations)}")
 Complete workflow for a high-risk medical AI system:
 
 ```python
-from services.identity_service import IdentityService
-from services.compliance_service import ComplianceService
-from services.provenance_service import ProvenanceService
-from services.credential_service import CredentialService
+from attestix.services.identity_service import IdentityService
+from attestix.services.compliance_service import ComplianceService
+from attestix.services.provenance_service import ProvenanceService
+from attestix.services.credential_service import CredentialService
 
 identity_svc = IdentityService()
 compliance_svc = ComplianceService()
@@ -281,8 +285,8 @@ if creds:
 Issue, verify, revoke, and present credentials:
 
 ```python
-from services.identity_service import IdentityService
-from services.credential_service import CredentialService
+from attestix.services.identity_service import IdentityService
+from attestix.services.credential_service import CredentialService
 
 identity_svc = IdentityService()
 credential_svc = CredentialService()
@@ -348,8 +352,8 @@ print(f"Credentials in VP: {len(vp['verifiableCredential'])}")
 Track agent trustworthiness with recency-weighted scoring:
 
 ```python
-from services.identity_service import IdentityService
-from services.reputation_service import ReputationService
+from attestix.services.identity_service import IdentityService
+from attestix.services.reputation_service import ReputationService
 
 identity_svc = IdentityService()
 reputation_svc = ReputationService()
@@ -402,8 +406,8 @@ print(f"Agents above 0.8: {len(top_agents)}")
 Log every agent action with hash-chained tamper-evident entries:
 
 ```python
-from services.identity_service import IdentityService
-from services.provenance_service import ProvenanceService
+from attestix.services.identity_service import IdentityService
+from attestix.services.provenance_service import ProvenanceService
 
 identity_svc = IdentityService()
 provenance_svc = ProvenanceService()
@@ -464,7 +468,7 @@ for entry in trail:
 Discover and parse A2A agent cards from remote services:
 
 ```python
-from services.agent_card_service import AgentCardService
+from attestix.services.agent_card_service import AgentCardService
 
 svc = AgentCardService()
 
@@ -495,9 +499,9 @@ print(f"Capabilities: {parsed['capabilities']}")
 Wrap any agent with compliance checks and audit logging:
 
 ```python
-from services.identity_service import IdentityService
-from services.compliance_service import ComplianceService
-from services.provenance_service import ProvenanceService
+from attestix.services.identity_service import IdentityService
+from attestix.services.compliance_service import ComplianceService
+from attestix.services.provenance_service import ProvenanceService
 
 
 class AttestixMiddleware:

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -15,8 +15,18 @@ Get your first AI agent identity in under 5 minutes.
 ## Installation
 
 ```bash
+# v0.4.0-rc.2 release candidate (canonical attestix.* namespace, recommended):
+pip install --pre attestix
+
+# Stable 0.3.0 (flat top-level packages, no namespace):
 pip install attestix
 ```
+
+v0.4.0-rc.2 ships the proper `attestix.*` namespace. The pre-rc.2 flat layout
+(`from services... import ...`) keeps working via deprecation shims and is
+scheduled for removal in v0.5.0. See the
+[namespace migration guide](/docs/guides/migration-v0.4.0-namespace) before
+upgrading existing code.
 
 Or install from source:
 
@@ -53,10 +63,7 @@ Claude will call `create_agent_identity` and return your agent's UAIT.
 ## Option B: Use as Python Library
 
 ```python
-import sys
-sys.path.insert(0, "/path/to/attestix")
-
-from services.identity_service import IdentityService
+from attestix.services.identity_service import IdentityService
 
 svc = IdentityService()
 agent = svc.create_identity(

--- a/website/content/docs/guides/base-l2-anchor.mdx
+++ b/website/content/docs/guides/base-l2-anchor.mdx
@@ -18,6 +18,10 @@ Anchoring is optional. Attestix works fully offline without it.
 ## Prerequisites
 
 ```bash
+# v0.4.0-rc.2 release candidate (canonical attestix.* namespace):
+pip install --pre attestix
+
+# Stable 0.3.0 still works (legacy flat layout, deprecation shims):
 pip install attestix
 ```
 
@@ -61,7 +65,7 @@ attestix blockchain balance
 Or programmatically in Python:
 
 ```python
-from services.blockchain_service import BlockchainService
+from attestix.services.blockchain_service import BlockchainService
 
 svc = BlockchainService()
 print(svc.balance())  # e.g. 0.0012 ETH on Base Sepolia

--- a/website/content/docs/guides/integration-guide.mdx
+++ b/website/content/docs/guides/integration-guide.mdx
@@ -34,10 +34,10 @@ Any MCP client can consume Attestix. The following ship with reference configs a
 You can import Attestix services directly without running the MCP server.
 
 ```python
-from services.identity_service import IdentityService
-from services.credential_service import CredentialService
-from services.compliance_service import ComplianceService
-from services.provenance_service import ProvenanceService
+from attestix.services.identity_service import IdentityService
+from attestix.services.credential_service import CredentialService
+from attestix.services.compliance_service import ComplianceService
+from attestix.services.provenance_service import ProvenanceService
 
 identity_svc = IdentityService()
 credential_svc = CredentialService()

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -10,6 +10,7 @@
     "openai-agents-sdk",
     "crewai",
     "offline-verify",
-    "base-l2-anchor"
+    "base-l2-anchor",
+    "migration-v0.4.0-namespace"
   ]
 }

--- a/website/content/docs/guides/migration-v0.4.0-namespace.mdx
+++ b/website/content/docs/guides/migration-v0.4.0-namespace.mdx
@@ -1,0 +1,160 @@
+---
+title: Migrating to the canonical attestix.* namespace (v0.4.0-rc.2)
+description: Move existing Attestix integrations from the legacy flat top-level packages (services/, auth/, ...) to the canonical attestix.* namespace before the deprecation shims are removed in v0.5.0.
+---
+
+# Migrating to the canonical `attestix.*` namespace
+
+`attestix` v0.4.0-rc.2 promotes every module into a proper `attestix.*`
+namespace. The legacy flat top-level packages (`services/`, `auth/`,
+`storage/`, ...) keep working as deprecation shims, but they emit a
+`DeprecationWarning` on first import and are scheduled for **removal in v0.5.0**.
+
+This guide covers why we changed the layout, what works today, the mechanical
+substitutions you need to apply, and how to verify the migration.
+
+## Why
+
+The ICP funnel evaluation that gated the v0.4.0 release found that pre-rc.2
+wheels were dropping flat top-level packages (`services/`, `auth/`,
+`storage/`, `signing/`, `audit/`, `tenancy/`, `idempotency/`, `blockchain/`,
+`api/`, `tools/`, plus `config.py`, `errors.py`, `main.py`, `cli.py`) directly
+into `site-packages` on every install. That polluted every consumer's
+namespace and forced the documented import to be `from services.X import Y`
+instead of the more conventional `from attestix.services.X import Y`. The
+evaluation reported that 9 of 12 ICP personas dropped at the Integrate step
+because of this.
+
+v0.4.0-rc.2 fixes the packaging without changing service behavior, the REST
+API, the MCP tools, or any on-disk format. It is byte-identical to rc.1 at
+runtime — only the import paths change.
+
+## What works today
+
+Both import paths resolve successfully in v0.4.0-rc.2:
+
+| Import path | Status in v0.4.0-rc.2 |
+|-------------|-----------------------|
+| `from attestix.services.identity_service import IdentityService` | Canonical. Recommended. |
+| `from services.identity_service import IdentityService` | Works. Emits `DeprecationWarning`. Removed in v0.5.0. |
+
+The legacy paths re-export from the canonical namespace, so the runtime
+behavior is identical. The `DeprecationWarning` fires once per legacy
+top-level package on first import and includes the canonical replacement
+path in the message.
+
+## Removal timeline
+
+| Version | Behavior |
+|---------|----------|
+| v0.4.0-rc.2 (current) | Both paths work. Legacy paths warn. |
+| v0.4.0 GA | Both paths work. Legacy paths warn. |
+| v0.5.0 | **Legacy paths removed.** Only `attestix.*` resolves. |
+
+Migrate before v0.5.0 to avoid `ImportError` on upgrade.
+
+## Mechanical migration
+
+The substitution is one-to-one: prefix every flat import with `attestix.`.
+
+### Before / after table
+
+| Legacy (pre-rc.2) | Canonical (v0.4.0-rc.2 and later) |
+|-------------------|-----------------------------------|
+| `from services.X import Y` | `from attestix.services.X import Y` |
+| `from auth.crypto import Y` | `from attestix.auth.crypto import Y` |
+| `from auth.ssrf import Y` | `from attestix.auth.ssrf import Y` |
+| `from auth.token_parser import Y` | `from attestix.auth.token_parser import Y` |
+| `from storage.X import Y` | `from attestix.storage.X import Y` |
+| `from signing.X import Y` | `from attestix.signing.X import Y` |
+| `from audit.X import Y` | `from attestix.audit.X import Y` |
+| `from tenancy import Y` | `from attestix.tenancy import Y` |
+| `from idempotency.X import Y` | `from attestix.idempotency.X import Y` |
+| `from blockchain.X import Y` | `from attestix.blockchain.X import Y` |
+| `from tools.X import Y` | `from attestix.tools.X import Y` |
+| `from api.X import Y` | `from attestix.api.X import Y` |
+| `from api.routers.X import Y` | `from attestix.api.routers.X import Y` |
+| `import services` (etc.) | `from attestix import services` |
+| `from config import …` | `from attestix.config import …` |
+| `from errors import …` | `from attestix.errors import …` |
+
+### One-liner for a whole codebase
+
+If your project already passes its tests against rc.2 (i.e. only the
+deprecation warnings remain), you can apply the migration mechanically with
+`ripgrep` + `sed`. Run from your project root:
+
+```bash
+rg -l --type py 'from (services|auth|storage|signing|audit|tenancy|idempotency|blockchain|tools|api|config|errors)\b' \
+  | xargs sed -i -E 's/^from (services|auth|storage|signing|audit|tenancy|idempotency|blockchain|tools|api|config|errors)(\.|\b)/from attestix.\1\2/'
+```
+
+Then re-run your test suite. Anything still emitting a `DeprecationWarning`
+about the `attestix` namespace is something the regex missed (typically
+multi-line imports inside parentheses); fix those by hand.
+
+For a dry-run preview without writing changes, drop the `-i` flag from `sed`
+and pipe to a paginer.
+
+### Deployment strings (uvicorn, gunicorn, Docker)
+
+Update the FastAPI app reference in every deployment config:
+
+| Where | Legacy | Canonical |
+|-------|--------|-----------|
+| `uvicorn` CLI | `uvicorn api.main:app` | `uvicorn attestix.api.main:app` |
+| `gunicorn` | `gunicorn api.main:app -k uvicorn.workers.UvicornWorker` | `gunicorn attestix.api.main:app -k uvicorn.workers.UvicornWorker` |
+| `Dockerfile` `CMD` | `CMD ["uvicorn", "api.main:app", ...]` | `CMD ["uvicorn", "attestix.api.main:app", ...]` |
+| `systemd` unit file | `ExecStart=... uvicorn api.main:app ...` | `ExecStart=... uvicorn attestix.api.main:app ...` |
+| MCP server config | `python /path/to/attestix/main.py` | `python -m attestix.main` |
+
+The `attestix` console script entry-point now resolves to `attestix.cli:cli`,
+so the `attestix ...` CLI commands continue to work unchanged.
+
+## Verification
+
+After migrating, you can prove that all of your imports go through the
+canonical namespace by treating `DeprecationWarning` as a hard error:
+
+```bash
+python -W error::DeprecationWarning -c \
+  "from attestix.services.identity_service import IdentityService; print('canonical ok')"
+```
+
+You should see `canonical ok`. If you still have any legacy imports anywhere
+in your application's import graph, this command will raise instead:
+
+```bash
+python -W error::DeprecationWarning -c "from services.identity_service import IdentityService"
+# -> DeprecationWarning: 'services' is a legacy alias for 'attestix.services';
+#    import from 'attestix.services' (legacy package will be removed in v0.5.0)
+```
+
+Run your own test suite under the same `-W error::DeprecationWarning` flag
+to catch every remaining legacy import in one pass.
+
+## Pin to rc.2 explicitly
+
+If you want to pin the exact version (recommended for any environment that
+isn't tracking the release-candidate line):
+
+```bash
+pip install --pre attestix==0.4.0rc2
+```
+
+For the rolling rc:
+
+```bash
+pip install --pre attestix
+```
+
+Stable 0.3.0 (still on the pre-rc.2 flat layout, no namespace) remains
+available via `pip install attestix` without `--pre` until v0.4.0 GA promotes
+the canonical wheel to default.
+
+## See also
+
+- [v0.4.0-rc.2 entry in `CHANGELOG.md`](https://github.com/VibeTensor/attestix/blob/main/CHANGELOG.md#040-rc2---2026-05-28)
+- [Getting Started](/docs/getting-started) — updated install command + canonical imports
+- [Examples](/docs/examples) — all snippets now use `attestix.*`
+- [Integration Guide](/docs/guides/integration-guide) — LangChain / OpenAI Agents SDK / CrewAI wiring on the canonical namespace

--- a/website/content/docs/guides/reputation.mdx
+++ b/website/content/docs/guides/reputation.mdx
@@ -30,8 +30,8 @@ The trust score ranges from 0.0 to 1.0:
 Every time an agent completes a task, record the outcome:
 
 ```python
-from services.identity_service import IdentityService
-from services.reputation_service import ReputationService
+from attestix.services.identity_service import IdentityService
+from attestix.services.reputation_service import ReputationService
 
 identity_svc = IdentityService()
 reputation_svc = ReputationService()
@@ -136,7 +136,7 @@ The scoring algorithm uses exponential moving average (EMA) with alpha = 0.08. T
 Reputation scores can inform delegation decisions. Before delegating capabilities to another agent, check their trust score:
 
 ```python
-from services.delegation_service import DelegationService
+from attestix.services.delegation_service import DelegationService
 
 delegation_svc = DelegationService()
 

--- a/website/content/docs/reference/faq.mdx
+++ b/website/content/docs/reference/faq.mdx
@@ -182,7 +182,7 @@ No hard limit, but JSON files are loaded entirely into memory on each operation.
 Yes. Import the service classes directly in Python:
 
 ```python
-from services.identity_service import IdentityService
+from attestix.services.identity_service import IdentityService
 svc = IdentityService()
 agent = svc.create_identity(display_name="MyAgent")
 ```


### PR DESCRIPTION
## Summary

Doc-only backfill for the v0.4.0-rc.2 packaging refactor (#91). Every Python snippet in the OSS docs now teaches the canonical `attestix.*` namespace instead of the pre-rc.2 flat top-level imports (`from services... import`, `from auth... import`, etc.). Adds a dedicated migration guide for users upgrading from 0.3.0 / rc.1.

- Rewrites all 17 legacy `from <flat>.X import Y` Python snippets in the website docs to `from attestix.<flat>.X import Y`.
- Updates install commands in the top three "first impression" pages (`examples`, `getting-started`, `base-l2-anchor`) to surface both `pip install --pre attestix` (rc.2) and `pip install attestix` (stable 0.3.0).
- Adds `website/content/docs/guides/migration-v0.4.0-namespace.mdx` covering the why (ICP funnel evaluation finding), what works today (both paths; legacy warns), removal timeline (v0.5.0), the full before/after substitution table, a one-liner `ripgrep + sed` script for bulk migration, deployment-string updates (`uvicorn api.main:app` → `uvicorn attestix.api.main:app`, plus `gunicorn` / `Dockerfile` / `systemd` / MCP forms), and verification commands using `-W error::DeprecationWarning`.
- Registers the new guide in `website/content/docs/guides/meta.json`.

No functional code change. The rc.2 wheel already ships the canonical namespace with deprecation shims for the legacy paths; this PR only updates what the docs teach.

## Files changed

8 files (7 modified, 1 new):

- `website/content/docs/examples.mdx`
- `website/content/docs/getting-started.mdx`
- `website/content/docs/guides/base-l2-anchor.mdx`
- `website/content/docs/guides/integration-guide.mdx`
- `website/content/docs/guides/meta.json`
- `website/content/docs/guides/reputation.mdx`
- `website/content/docs/reference/faq.mdx`
- `website/content/docs/guides/migration-v0.4.0-namespace.mdx` (new)

The README is already canonical (touched in #91) so no edits there.

## Validation

### Website build
`npx next build` in `website/`: 60/60 static pages, including the new `/docs/guides/migration-v0.4.0-namespace` route. Built artifact verified at `website/out/docs/guides/migration-v0.4.0-namespace.html`.

### Grep for residual legacy imports
After edits, the post-edit grep across `website/` + `README.md`, excluding the migration guide which intentionally quotes both forms:

```
README.md:51-52    # narrative text inside the rc.2 callout (`from services... import`)
README.md:72,249   # already-canonical `attestix.api.main:app`
examples.mdx:11             # narrative callout linking to the migration guide
getting-started.mdx:26      # narrative callout linking to the migration guide
contributing.mdx:54         # natural-language "Services never import from tools"
```

Zero literal legacy `from <flat>.X import` Python imports remain in any code block.

### rc.2 smoke test (throwaway venv)
```
$ pip install --pre attestix==0.4.0rc2
$ python -c "from attestix.services.identity_service import IdentityService; print('canonical ok:', IdentityService.__module__)"
canonical ok: attestix.services.identity_service

$ python -W error::DeprecationWarning -c "from attestix.services.identity_service import IdentityService"
# exits 0 — no warning, no error

$ python -W error::DeprecationWarning -c "from services.identity_service import IdentityService"
DeprecationWarning: Importing from the top-level `services` package is deprecated
and will be removed in Attestix v0.5.0. Update your imports to
`from attestix.services...` (canonical namespace).
```

The canonical path passes under strict warnings; the legacy path raises with the exact replacement guidance the migration guide documents.

## Test plan

- [ ] Visit https://attestix.io/docs/guides/migration-v0.4.0-namespace after merge and confirm the page renders.
- [ ] Spot-check that `/docs/getting-started`, `/docs/examples`, `/docs/guides/integration-guide`, `/docs/guides/reputation`, `/docs/guides/base-l2-anchor`, `/docs/reference/faq` all show `from attestix.services... import ...` in code blocks.
- [ ] Confirm the install block on `/docs/getting-started` mentions both `pip install --pre attestix` and `pip install attestix`.
- [ ] (Optional) Re-run the smoke test above in a fresh venv to reproduce the verification numbers locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all code examples and getting-started guides to reflect the latest v0.4.0-rc.2 release.
  * Added new migration guide to help users transition from legacy import patterns to the current recommended approach.
  * Clarified installation instructions and deprecation timeline for future versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VibeTensor/attestix/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->