### PR TITLE
docs(website): 10 per-ICP quickstart pages (Fumadocs) — funnel-eval-driven

### DIFF
--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -7,6 +7,10 @@ description: Get your first AI agent identity in under 5 minutes.
 
 Get your first AI agent identity in under 5 minutes.
 
+<Callout title="Looking for a role-specific path?">
+The [quickstart pages](/docs/quickstart) cover 10 ICP personas (indie dev, fintech compliance, healthcare ML, enterprise architect, GRC consultant, DevTools skeptic, web3, AI safety, startup CTO, MLOps). Each is a 90-second-readable copy-paste path written against the exact pain point that persona hit in the v0.4.0 funnel evaluation.
+</Callout>
+
 ## Prerequisites
 
 - Python 3.10 or later

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -3,6 +3,8 @@
   "pages": [
     "index",
     "getting-started",
+    "---Quickstart by role---",
+    "quickstart",
     "examples",
     "---Guides---",
     "guides",

--- a/website/content/docs/quickstart/ai-safety-research.mdx
+++ b/website/content/docs/quickstart/ai-safety-research.mdx
@@ -1,0 +1,97 @@
+---
+title: AI safety researcher — Quickstart
+description: Produce signed, hash-chained telemetry from an LLM-agent eval run that other labs can re-verify offline. No backend, no cloud.
+---
+
+## You're here because…
+
+You work on agent evaluation / interpretability / monitor evals and you want a citable evidence layer for what an agent did during a run. The funnel evaluation flagged that the safety persona was one of two TRIAL verdicts, but still dropped at integration because the path from "run my eval" to "produce a verifiable, replayable artefact bundle" wasn't laid out. This page is that path: a single Python session that captures structured agent telemetry into a hash-chained audit log, then issues a signed credential bundle another lab can verify offline.
+
+## 60-second install
+
+```bash
+pip install --pre attestix
+```
+
+No network calls are made for any of the steps below; everything serialises to local JSON.
+
+## First 30 lines that actually do something
+
+```python
+from attestix.services.identity_service import IdentityService
+from attestix.services.provenance_service import ProvenanceService
+from attestix.services.credential_service import CredentialService
+
+# 1. Register the eval subject (the agent being studied).
+subject = IdentityService().create_identity(
+    display_name="probe-target-2026-05-28",
+    source_protocol="manual",
+    capabilities=["text_generation"],
+    description="Subject of safety eval run #042",
+    issuer_name="VibeTensor",  # change to your lab's DID issuer name
+)
+subject_id = subject["agent_id"]
+
+# 2. Pin the model lineage (so the run is reproducible).
+ProvenanceService().record_model_lineage(
+    agent_id=subject_id,
+    base_model="gpt-4o-2024-08-06",
+    base_model_provider="OpenAI",
+    fine_tuning_method="none (zero-shot eval)",
+    evaluation_metrics={"helpful_only_judge_pass": 0.84, "monitor_recall": 0.71},
+)
+
+# 3. Log every probe -> response as a hash-chained audit entry.
+prov = ProvenanceService()
+for probe_id, prompt, completion, monitor_score in your_eval_iter():
+    prov.log_action(
+        agent_id=subject_id,
+        action_type="inference",
+        input_summary=f"probe={probe_id}; prompt_sha256={prompt_hash(prompt)}",
+        output_summary=f"completion_sha256={prompt_hash(completion)}; monitor={monitor_score}",
+        decision_rationale="eval-run-042; monitor=white_box_v3",
+    )
+
+# 4. Bundle the run as a signed credential another lab can verify offline.
+run_cred = CredentialService().issue_credential(
+    agent_id=subject_id,
+    credential_type="EvaluationRunCredential",
+    issuer_name="VibeTensor",
+    claims={
+        "run_id": "eval-run-042",
+        "subject": subject_id,
+        "monitor": "white_box_v3",
+        "audit_entries": prov.get_provenance(subject_id)["audit_log_count"],
+    },
+)
+print(run_cred["id"], run_cred["proof"]["type"])  # Ed25519Signature2020
+```
+
+## What you just got
+
+- A signed `EvaluationRunCredential` (W3C VC 1.1 + `Ed25519Signature2020`) pinning the run id, subject DID, monitor name, and entry count.
+- A hash-chained Article 12-style audit trail (`prev_hash` -> `entry_hash`) that any third lab can re-derive from the JSON without contacting you.
+- Reproducibility metadata (model name, provider, eval metrics) recorded under the same agent DID.
+
+## Verifying offline (what a reviewer would run)
+
+```python
+from attestix.services.credential_service import CredentialService
+result = CredentialService().verify_credential(run_cred["id"])
+print(result["valid"], result["checks"])  # signature_valid, not_revoked, ...
+```
+
+Or pass the credential JSON directly to `verify_credential_external(credential_dict)` so the reviewer never has to import your local store.
+
+## Next step (5 minutes)
+
+To make the bundle citable, anchor the audit batch's Merkle root to **Base Sepolia testnet** (mainnet anchoring is on the roadmap; testnet anchors are timestamped evidence, not legal non-repudiation):
+
+```python
+from attestix.services.blockchain_service import BlockchainService
+print(BlockchainService().anchor_audit_batch(agent_id=subject_id))
+```
+
+You can then cite the attestation UID alongside the credential in your paper; any reviewer can query EAS on Base Sepolia to confirm the bundle existed at the cited block height.
+
+If you want the wider context — UCAN delegations for multi-agent eval setups, the full audit-row schema, the canonical-JSON spec — see the [offline verify guide](/docs/guides/offline-verify) and the [API reference](/docs/reference/api-reference).

--- a/website/content/docs/quickstart/devtools-skeptic.mdx
+++ b/website/content/docs/quickstart/devtools-skeptic.mdx
@@ -1,0 +1,81 @@
+---
+title: DevTools / DX skeptic — Quickstart
+description: Does the package actually import? Yes, in v0.4.0-rc.2. Here's the smallest possible test you can run in 60 seconds to verify the DX claim before reading anything else.
+---
+
+## You're here because…
+
+You're a senior DX-minded developer and the funnel evaluation said the previous Attestix install required `sys.path.insert` to a cloned repo because `pip install attestix` dropped flat top-level packages (`services/`, `auth/`, `storage/`, …) into `site-packages`. That was the cheapest, loudest failure across the whole ICP review. v0.4.0-rc.2 fixes it. This page exists so you can prove that, end-to-end, in under a minute, without reading any other doc.
+
+## 60-second install
+
+```bash
+python -m venv /tmp/attestix-smoketest && \
+  . /tmp/attestix-smoketest/bin/activate && \
+  pip install --pre attestix
+```
+
+Windows PowerShell:
+
+```powershell
+python -m venv $env:TEMP\attestix-smoketest
+& $env:TEMP\attestix-smoketest\Scripts\Activate.ps1
+pip install --pre attestix
+```
+
+## First 30 lines that actually do something
+
+```python
+# smoketest.py — runs from any directory, no sys.path hack.
+from attestix.services.identity_service import IdentityService
+
+svc = IdentityService()
+agent = svc.create_identity(
+    display_name="smoketest",
+    source_protocol="manual",
+    capabilities=["test"],
+    issuer_name="VibeTensor",
+)
+verification = svc.verify_identity(agent["agent_id"])
+assert verification["valid"], verification
+print("OK", agent["agent_id"], agent["issuer"]["did"])
+```
+
+Run it:
+
+```bash
+python smoketest.py
+# OK attestix:abc... did:key:z6Mk...
+```
+
+Then prove there are no legacy imports anywhere in your dependency graph:
+
+```bash
+python -W error::DeprecationWarning -c \
+  "from attestix.services.identity_service import IdentityService; print('canonical ok')"
+```
+
+If you see `canonical ok` and zero stderr, the import surface is clean. If you see a `DeprecationWarning` it means something in your tree is still hitting the legacy flat shim (`from services...`, `from auth...`, etc.) — see the [namespace migration guide](/docs/guides/migration-v0.4.0-namespace).
+
+## What you just got
+
+- Proof the package imports from a clean venv with no path hacks.
+- A signed Ed25519 identity row in `identities.json` (cwd-relative). Delete the file to reset.
+- A canonical `attestix.*` import path that maps 1:1 to every module name — same names you'd discover via `python -c "import attestix; help(attestix)"`.
+
+## Honest things you should know before sending this to your team
+
+- v0.4.0-rc.2 is a release candidate. The legacy flat top-level packages (`services/`, `auth/`, `storage/`, …) are still installed as deprecation shims and **will be removed in v0.5.0**.
+- Single maintainer, ~15 GitHub stars, no third-party security audit. The package is functional but not yet enterprise-hardened — see the [enterprise architect quickstart](/docs/quickstart/enterprise-architect) for the explicit gap list.
+- The signing key lives in `.signing_key.json` in the working directory and is plaintext by default. Set `ATTESTIX_KEY_PASSPHRASE` to enable AES-256-GCM encryption at rest.
+
+## Next step (5 minutes)
+
+If the smoke test passed and you want to see the actual product surface, clone the repo and run the bundled end-to-end example (9-step compliance workflow, ~3 seconds):
+
+```bash
+git clone https://github.com/VibeTensor/attestix.git
+python attestix/examples/quickstart.py
+```
+
+Or jump straight to the [Integration Guide](/docs/guides/integration-guide) for LangChain / OpenAI Agents / CrewAI wiring.

--- a/website/content/docs/quickstart/enterprise-architect.mdx
+++ b/website/content/docs/quickstart/enterprise-architect.mdx
@@ -1,0 +1,92 @@
+---
+title: Enterprise platform architect — Quickstart
+description: Run Attestix as a service behind your own ingress. Multi-tenant context, idempotent REST, hash-chained audit. Honest about what's not in v0.4.0.
+---
+
+## You're here because…
+
+You're evaluating whether Attestix can sit inside an enterprise platform as a deployable service, not a CLI. The funnel evaluation flagged that enterprise evaluators got past install but dropped at integration — file-based storage, one signing key, no RBAC, no multi-tenant isolation, no KMS. **Most of that is still true in v0.4.0.** What v0.4.0 *does* ship: a proper Python package, idempotent REST endpoints, audit events per service, and an in-process tenant context. The honest gaps are listed at the bottom of this page so your architecture review can land on them now.
+
+## 60-second install
+
+```bash
+pip install --pre 'attestix[api]'
+```
+
+Run as a service:
+
+```bash
+uvicorn attestix.api.main:app --host 0.0.0.0 --port 8000
+```
+
+Or as an MCP server over HTTP for AI workloads:
+
+```bash
+attestix mcp --transport http --port 8501
+```
+
+## First 30 lines that actually do something
+
+```python
+# A minimal multi-tenant call against the running service.
+# Idempotency is honoured via the Idempotency-Key header (Stripe-style).
+import os, requests, uuid
+
+BASE = os.environ.get("ATTESTIX_URL", "http://localhost:8000")
+
+resp = requests.post(
+    f"{BASE}/identities",
+    json={
+        "display_name": "platform-issued-agent",
+        "source_protocol": "manual",
+        "capabilities": ["data_analysis"],
+        "issuer_name": "VibeTensor",
+    },
+    headers={
+        "Idempotency-Key": str(uuid.uuid4()),
+        # In a multi-tenant deployment, your gateway maps an authenticated
+        # principal to a tenant id and stamps this header before forwarding.
+        "X-Tenant-Id": "tenant_a",
+    },
+    timeout=10,
+)
+resp.raise_for_status()
+agent = resp.json()
+print(agent["agent_id"], agent["issuer"]["did"])
+
+# Subsequent reads scope to the same tenant.
+trail = requests.get(
+    f"{BASE}/audit/{agent['agent_id']}",
+    headers={"X-Tenant-Id": "tenant_a"},
+).json()
+print(len(trail), "audit rows so far")
+```
+
+## What you just got
+
+- An HTTP service exposing the 44 REST endpoints (`/identities`, `/credentials`, `/compliance`, `/audit`, `/delegations`, …) — same surface as the 47 MCP tools.
+- An idempotency middleware: repeating the same `Idempotency-Key` returns the cached response, not a duplicate write.
+- A tenant context header (`X-Tenant-Id`) that is plumbed through every service and stamped onto audit events. Pair it with your existing OIDC / mTLS edge.
+
+## Next step (5 minutes)
+
+Wire structured audit shipping to your SIEM. Audit events emit as JSON lines into `audit_log.jsonl` (rotateable); the simplest path is a sidecar tailing it:
+
+```bash
+tail -F audit_log.jsonl | your-siem-shipper --type attestix
+```
+
+The deeper [architecture guide](/docs/guides/architecture) covers the service decomposition (9 services), the on-disk format, and the hash-chain layout.
+
+## Open caveats for enterprise production
+
+These are explicit gaps in v0.4.0; track them on the [roadmap](/docs/project/roadmap):
+
+| Concern | v0.4.0 reality |
+|---|---|
+| Storage | Flat JSON files. Postgres / S3 backend is planned. |
+| Signing key | `.signing_key.json`, plaintext by default. Encrypted-at-rest is opt-in via `ATTESTIX_KEY_PASSPHRASE`. KMS / HSM / Vault is planned. |
+| RBAC / IAM | Tenant header is honoured by services; full RBAC + OIDC / SAML mapping is not in scope for v0.4.0. |
+| HA | Single-process. Multi-replica with shared state needs the pluggable storage backend first. |
+| Third-party security audit | None to date. |
+| Anchoring | Base L2 **testnet** only (Sepolia). Mainnet schema registration on the roadmap. |

--- a/website/content/docs/quickstart/fintech-compliance.mdx
+++ b/website/content/docs/quickstart/fintech-compliance.mdx
@@ -1,0 +1,93 @@
+---
+title: Fintech compliance engineer — Quickstart
+description: Wire a trading or credit-scoring agent with hash-chained audit, signed inference logs, and a third-party conformity assessment record — without a database.
+---
+
+## You're here because…
+
+You're a compliance engineer on a fintech / trading-agent stack. The funnel evaluation flagged that fintech evaluators dropped at install because the legacy package needed a `sys.path` hack and because Base L2 anchoring is **testnet only** — not legally binding for trading audit yet. v0.4.0-rc.2 fixes the import problem (`pip install --pre attestix` gives you the canonical `attestix.*` namespace). The testnet caveat still applies and is called out below.
+
+## 60-second install
+
+```bash
+pip install --pre attestix
+```
+
+If you want the FastAPI surface for an internal service:
+
+```bash
+pip install --pre 'attestix[api]'
+attestix mcp --transport http --port 8501
+```
+
+## First 30 lines that actually do something
+
+```python
+from attestix.services.identity_service import IdentityService
+from attestix.services.compliance_service import ComplianceService
+from attestix.services.provenance_service import ProvenanceService
+
+identity = IdentityService().create_identity(
+    display_name="credit-scorer-v1",
+    source_protocol="manual",
+    capabilities=["credit_scoring", "risk_assessment"],
+    issuer_name="VibeTensor",
+)
+agent_id = identity["agent_id"]
+
+# Article 10 / training-data provenance
+ProvenanceService().record_training_data(
+    agent_id=agent_id,
+    dataset_name="Internal Loan Book 2020-2025",
+    source_url="https://data.internal/loans",
+    license="Proprietary",
+    data_categories=["financial", "credit_history"],
+    contains_personal_data=True,
+    data_governance_measures="De-identified per GDPR Art. 5. Quarterly bias audit.",
+)
+
+# Compliance profile + risk classification
+ComplianceService().create_compliance_profile(
+    agent_id=agent_id,
+    risk_category="high",  # credit scoring -> Annex III high-risk
+    provider_name="VibeTensor",
+    intended_purpose="Automated credit scoring for consumer loans",
+    human_oversight_measures="Loan officer reviews every AI recommendation before approval.",
+)
+
+# Article 43: high-risk systems CANNOT self-assess; record third-party result.
+ComplianceService().record_conformity_assessment(
+    agent_id=agent_id,
+    assessment_type="third_party",
+    assessor_name="Bureau Veritas",
+    result="pass",
+    ce_marking_eligible=True,
+)
+
+declaration = ComplianceService().generate_declaration_of_conformity(agent_id)
+print(declaration["declaration_id"])
+```
+
+## What you just got
+
+- Article 10 training-data record + Article 11 model-lineage record (call `record_model_lineage` for the latter) — both Ed25519-signed.
+- An Article 43 third-party assessment row. The service **refuses** to record a `self`-assessment for high-risk; that gate is in the code.
+- An Annex V Declaration of Conformity. Bundle it with the compliance VCs into a Verifiable Presentation for a regulator (see [EU AI Act compliance guide](/docs/guides/eu-ai-act-compliance)).
+
+Every inference your trading agent makes should be logged through `ProvenanceService().log_action(...)` — that's the hash-chained Article 12 trail you'll show an auditor.
+
+## Next step (5 minutes)
+
+For inference-time logging in your prediction loop:
+
+```python
+ProvenanceService().log_action(
+    agent_id=agent_id,
+    action_type="inference",
+    input_summary="Loan application LA-2026-4821, income=65K",
+    output_summary="Risk score 0.23, recommend APPROVE",
+    decision_rationale="Score below 0.3 threshold.",
+)
+```
+
+**Open caveats for fintech production:** there is no SOC 2 / ISO 27001 today, no DPA template, the signing key is plaintext-by-default (`.signing_key.json`), and Base L2 anchoring is testnet — so the cryptographic chain proves integrity locally, but is not yet a legally non-repudiable anchor. Track these on the [roadmap](/docs/project/roadmap).

--- a/website/content/docs/quickstart/grc-consultant.mdx
+++ b/website/content/docs/quickstart/grc-consultant.mdx
@@ -1,0 +1,117 @@
+---
+title: EU AI Act / GRC consultant — Quickstart
+description: Generate Annex IV technical documentation and an Annex V Declaration of Conformity for a client's high-risk AI system. Honest about where cryptographic integrity ends and human / notified-body sign-off begins.
+---
+
+## You're here because…
+
+You're consulting on EU AI Act readiness and you need a tool that produces *machine-readable* evidence for Annex IV / Annex V — not another GRC dashboard. The funnel evaluation flagged that the GRC persona was one of only two TRIAL verdicts, but still dropped at integration because the docs conflated cryptographic integrity with regulatory conformity. This page de-conflates them: a signed VC proves an artefact existed and wasn't tampered with; it does **not** replace notified-body sign-off for high-risk systems.
+
+## 60-second install
+
+```bash
+pip install --pre attestix
+```
+
+## First 30 lines that actually do something
+
+```python
+from attestix.services.identity_service import IdentityService
+from attestix.services.provenance_service import ProvenanceService
+from attestix.services.compliance_service import ComplianceService
+from attestix.services.credential_service import CredentialService
+
+agent_id = IdentityService().create_identity(
+    display_name="client-hr-screener",
+    source_protocol="manual",
+    capabilities=["cv_screening", "candidate_ranking"],
+    issuer_name="Client Co. (assessed by VibeTensor)",
+)["agent_id"]
+
+ProvenanceService().record_training_data(
+    agent_id=agent_id,
+    dataset_name="Client historical hiring records 2020-2024",
+    source_url="internal://client/hr",
+    license="Proprietary",
+    data_categories=["employment", "demographics"],
+    contains_personal_data=True,
+    data_governance_measures="Removed protected attributes per Art. 10(2)(f). Bias audit Q4-2025.",
+)
+
+# Annex III §4(a) — employment / HR screening = high-risk
+ComplianceService().create_compliance_profile(
+    agent_id=agent_id,
+    risk_category="high",
+    provider_name="Client Co.",
+    intended_purpose="Initial CV screening with human reviewer in the loop.",
+    human_oversight_measures="Recruiter reviews shortlist; no automated rejection.",
+    transparency_obligations="Candidates informed of AI assistance per Article 50.",
+)
+
+# Article 43 — record the third-party assessment your client procured.
+ComplianceService().record_conformity_assessment(
+    agent_id=agent_id,
+    assessment_type="third_party",
+    assessor_name="Notified Body NB-0482",
+    result="pass",
+    findings="System meets Annex III §4(a) requirements with documented oversight.",
+    ce_marking_eligible=True,
+)
+
+declaration = ComplianceService().generate_declaration_of_conformity(agent_id)
+print(declaration["declaration_id"])  # signed Annex V document id
+```
+
+## What you just got
+
+- An Annex IV-shaped technical documentation bundle (identity + training data + model lineage + compliance profile + audit trail), every entry Ed25519-signed.
+- A signed Annex V Declaration of Conformity — issued only after a third-party assessment row exists, because the service refuses to declare conformity on a self-assessment for high-risk systems.
+- A path to bundle the evidence into a W3C Verifiable Presentation for the regulator:
+
+```python
+vp = CredentialService().create_verifiable_presentation(
+    holder_id=agent_id,
+    credentials=[declaration["credential_id"]],
+    verifier="did:web:eu.regulator",
+    challenge="ch_audit_2026",
+)
+```
+
+## What this does NOT prove
+
+Read this section before billing a client. It is the single most important distinction in the product.
+
+| Attestix proves… | Attestix does NOT prove |
+|---|---|
+| The declaration existed at this hash | A notified body has approved CE marking |
+| The third-party assessment row was recorded by this issuer DID | The assessor's findings are factually sound |
+| The audit trail is internally consistent (hash chain unbroken) | The agent's actual behaviour matched the declared purpose |
+| The signing key controlled by this issuer signed the artefact | Legal liability has shifted from provider to anyone else |
+
+Provider liability under Articles 16–22 stays with the provider regardless of what Attestix outputs. See the [EU compliance walkthrough](/docs/guides/eu-compliance-walkthrough) for the full mapping.
+
+## Next step (5 minutes)
+
+Pull the full hash-chained Article 12 trail for the client's audit binder:
+
+```bash
+attestix audit <agent_id> --limit 500 > client-audit-2026.jsonl
+```
+
+Inspect the chained provenance bundle (training data + model lineage + audit log) for the binder:
+
+```python
+from attestix.services.provenance_service import ProvenanceService
+bundle = ProvenanceService().get_provenance(agent_id)
+print(bundle["audit_log_count"], "audit rows;",
+      len(bundle.get("training_data", [])), "datasets")
+```
+
+Each row in `get_audit_trail(agent_id)` carries the `prev_hash` and `entry_hash` fields — a third party can re-derive the chain offline without contacting Attestix.
+
+If you want an on-ledger commitment so the client can prove the bundle existed at a block height, add a Base **Sepolia testnet** anchor (mainnet schema is on the roadmap — testnet anchors are **not** legally non-repudiable):
+
+```python
+from attestix.services.blockchain_service import BlockchainService
+print(BlockchainService().anchor_audit_batch(agent_id=agent_id))
+```

--- a/website/content/docs/quickstart/healthcare-ml.mdx
+++ b/website/content/docs/quickstart/healthcare-ml.mdx
@@ -1,0 +1,82 @@
+---
+title: Healthcare ML lead — Quickstart
+description: Record training-data provenance, model lineage, and an Annex III high-risk profile for a clinical decision-support agent. GDPR Article 17 erasure included; DPDP / HIPAA-adjacent obligations called out honestly.
+---
+
+## You're here because…
+
+You're an ML lead on a clinical / healthcare stack and you need provenance-grade documentation before the agent touches a patient record. The funnel evaluation flagged that healthcare evaluators continued past install but dropped at integration — there was no copy-paste path that produced an Annex III high-risk profile plus a model-lineage record in one go. This page is that path. **DPDP / HIPAA-adjacent coverage is not implemented in v0.4.0**; what you get today is EU AI Act + GDPR Article 17 erasure.
+
+## 60-second install
+
+```bash
+pip install --pre attestix
+```
+
+## First 30 lines that actually do something
+
+```python
+from attestix.services.identity_service import IdentityService
+from attestix.services.provenance_service import ProvenanceService
+from attestix.services.compliance_service import ComplianceService
+
+agent_id = IdentityService().create_identity(
+    display_name="triage-assist-v2",
+    source_protocol="manual",
+    capabilities=["clinical_triage", "risk_stratification"],
+    issuer_name="VibeTensor",
+)["agent_id"]
+
+# Article 10 — training data provenance (de-identified clinical set)
+ProvenanceService().record_training_data(
+    agent_id=agent_id,
+    dataset_name="MIMIC-IV de-identified ED triage subset",
+    source_url="https://physionet.org/content/mimiciv/",
+    license="PhysioNet Credentialed Health Data Use Agreement",
+    data_categories=["clinical_notes", "vitals", "demographics"],
+    contains_personal_data=True,
+    data_governance_measures="De-identified per HIPAA Safe Harbor. IRB approval IRB-2026-0042.",
+)
+
+# Article 11 — model lineage + evaluation metrics
+ProvenanceService().record_model_lineage(
+    agent_id=agent_id,
+    base_model="clinicalBERT-base",
+    base_model_provider="EMNLP Clinical NLP",
+    fine_tuning_method="LoRA SFT on de-identified ED notes",
+    evaluation_metrics={"auc_roc": 0.89, "sensitivity": 0.93, "specificity": 0.82},
+)
+
+# Annex III high-risk profile
+ComplianceService().create_compliance_profile(
+    agent_id=agent_id,
+    risk_category="high",
+    provider_name="VibeTensor",
+    intended_purpose="ED triage decision support (Annex III §5(a) — access to essential services)",
+    human_oversight_measures="Clinician reviews every triage recommendation before action.",
+    transparency_obligations="Patient-facing disclosure of AI involvement per Article 50.",
+)
+```
+
+## What you just got
+
+- A signed Article 10 + Article 11 record per dataset and per fine-tuning run — every regulator's first ask.
+- A high-risk profile gated under Annex III. The conformity-assessment service will block self-assessment and require a third-party result before issuing a Declaration of Conformity.
+- A GDPR Article 17 erasure path (`identity_svc.revoke_identity(agent_id, reason="erasure")`) — the only data-subject-rights primitive implemented today.
+
+## Next step (5 minutes)
+
+Log every clinical inference into the hash-chained Article 12 audit trail (no PHI in the payload — pass hashes / case IDs):
+
+```python
+ProvenanceService().log_action(
+    agent_id=agent_id,
+    action_type="inference",
+    input_summary="Case CR-7421 (vitals + chief complaint hash sha256:a91…)",
+    output_summary="Triage band: ESI-2; recommend immediate clinician review.",
+    decision_rationale="Tachycardia + chest pain + age>65 -> ESI-2 per CDS rules.",
+    human_override=False,
+)
+```
+
+**Open caveats for healthcare production:** there is no third-party security audit, no HIPAA BAA template, and **DPDP (India) coverage is referenced in marketing but is planned for v0.5 — it is not implemented in v0.4.0**. GDPR Article 17 (erasure) is the only data-subject-rights primitive shipped today. Treat all output as evidence under your existing legal review, not as legal sign-off.

--- a/website/content/docs/quickstart/index.mdx
+++ b/website/content/docs/quickstart/index.mdx
@@ -1,0 +1,36 @@
+---
+title: Quickstart — pick your role
+description: Copy-paste to verifiable agents in 90 seconds. One page per ICP persona from the v0.4.0 funnel evaluation, written against the actual pain point that persona hit.
+---
+
+# Quickstart
+
+Pick the page that matches your role. Every page is **90-second-readable** with a copy-paste path that runs against a clean `pip install --pre attestix` (v0.4.0-rc.2, canonical `attestix.*` namespace).
+
+The 10 pages below correspond to the 10 ICP personas surfaced in the [v0.4.0 funnel evaluation](https://github.com/VibeTensor/attestix/blob/main/CHANGELOG.md#040-rc2---2026-05-28). Each one targets the exact step at which that persona dropped off.
+
+| You are… | Start here |
+|---|---|
+| Indie AI-agent dev building a LangChain RAG agent | [Indie dev →](/docs/quickstart/indie-dev) |
+| Fintech compliance engineer wiring auditability into a trading or scoring agent | [Fintech compliance →](/docs/quickstart/fintech-compliance) |
+| Healthcare ML lead building a clinical decision-support agent | [Healthcare ML →](/docs/quickstart/healthcare-ml) |
+| Enterprise platform architect evaluating a self-hosted attestation layer | [Enterprise architect →](/docs/quickstart/enterprise-architect) |
+| EU AI Act / GRC consultant collecting Annex IV / Annex V evidence | [GRC consultant →](/docs/quickstart/grc-consultant) |
+| Senior DevTools / DX skeptic checking whether the package actually imports | [DevTools skeptic →](/docs/quickstart/devtools-skeptic) |
+| Web3 / blockchain dev anchoring artefacts to Base L2 testnet | [Web3 / on-chain →](/docs/quickstart/web3-onchain) |
+| Academic AI-safety researcher wanting verifiable agent telemetry | [AI safety research →](/docs/quickstart/ai-safety-research) |
+| Startup CTO running a build-vs-buy evaluation for agent governance | [Startup CTO →](/docs/quickstart/startup-cto) |
+| MLOps engineer wiring attestation into CI/CD and a model pipeline | [MLOps engineer →](/docs/quickstart/mlops-engineer) |
+
+## Honesty rules these pages follow
+
+The v0.4.0 ICP funnel evaluation surfaced three universal failures: a broken package import, an over-claim of maturity, and conflating cryptographic integrity with regulatory conformity. These pages do not repeat them.
+
+- Base L2 anchoring is **Base Sepolia testnet only** in v0.4.0. Mainnet schema registration is on the roadmap. Every code sample that mentions anchoring says so.
+- DPDP (India) is **referenced but not implemented**. GDPR Article 17 (erasure) is implemented. Anything DPDP-shaped is called out as planned for v0.5.
+- LangChain, OpenAI Agents SDK, and CrewAI are **real** integrations (shipped v0.3.0). Dify, Google ADK, Semantic Kernel, and Strands are **example-only** (MCP-config templates, not first-party adapters).
+- Maturity is **beta with one maintainer**. There is no third-party security audit. The signing key is stored locally by default. Treat artefacts produced today as evidence, not as a substitute for legal counsel or a notified body.
+
+## If none of these fit you
+
+Start with the [Getting Started page](/docs/getting-started) (5-minute end-to-end) and then jump into the [Integration Guide](/docs/guides/integration-guide) or the [API reference](/docs/reference/api-reference) (47 MCP tools, 44 REST endpoints).

--- a/website/content/docs/quickstart/indie-dev.mdx
+++ b/website/content/docs/quickstart/indie-dev.mdx
@@ -1,0 +1,81 @@
+---
+title: Indie AI-agent dev — Quickstart
+description: For the solo founder shipping a LangChain RAG agent fast. Skip the boilerplate, get a hash-chained audit trail and a signed VC on every chain completion.
+---
+
+## You're here because…
+
+You're a solo or small-team dev shipping a LangChain agent and you don't have time to hand-roll an audit trail before launch. The funnel evaluation flagged that the "5-minute promise" used to break at the import step — `from services.identity_service import …` only worked from a cloned repo, not from a clean `pip install`. v0.4.0-rc.2 ships the canonical `attestix.*` namespace, so the snippet below runs end-to-end from a fresh venv.
+
+## 60-second install
+
+```bash
+pip install --pre 'attestix[langchain]'
+```
+
+That installs v0.4.0-rc.2 plus the `langchain-core` extra. Drop the `--pre` once v0.4.0 GA ships.
+
+## First 30 lines that actually do something
+
+```python
+from langchain.agents import AgentExecutor, create_react_agent
+from langchain_core.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI
+from attestix.integrations.langchain import AttestixCallback
+from attestix.services.identity_service import IdentityService
+
+# 1. One-time: create the agent identity (signed, persisted to identities.json).
+agent = IdentityService().create_identity(
+    display_name="rag-helper",
+    source_protocol="manual",
+    capabilities=["retrieval", "synthesis"],
+    issuer_name="VibeTensor",
+    expiry_days=365,
+)
+
+# 2. Wire the callback. Every tool call, LLM call, and chain step gets
+#    SHA-256 hash-chained, Ed25519-signed, and stored locally.
+callback = AttestixCallback(
+    agent_id=agent["agent_id"],
+    record_llm_tokens=True,
+    issue_vc_on_success=True,  # default True
+)
+
+llm = ChatOpenAI(model="gpt-4o-mini")
+prompt = PromptTemplate.from_template("{input}\n{agent_scratchpad}")
+executor = AgentExecutor(
+    agent=create_react_agent(llm, tools=[], prompt=prompt),
+    tools=[],
+    callbacks=[callback],
+)
+
+result = executor.invoke({"input": "Summarise our Q4 board pack."})
+print(result["output"])
+```
+
+## What you just got
+
+- A row in the local hash-chained audit trail for every callback event (`on_chain_start`, `on_tool_start`, `on_llm_end`, `on_chain_end`).
+- A signed `ChainExecutionCredential` (W3C VC, `Ed25519Signature2020`) auto-issued on chain completion — verify it offline with `attestix credential --verify <cred_id>`.
+- A persistent agent DID so the same identity is reused across runs (no per-run re-creation).
+
+Verify the chain hashes still line up:
+
+```bash
+attestix audit <agent_id>
+```
+
+The deeper [LangChain integration guide](/docs/guides/langchain) covers chain-of-thought events, sub-chain UCAN delegations, and the full callback event table.
+
+## Next step (5 minutes)
+
+Anchor today's audit batch to **Base L2 testnet** (Sepolia, free, requires a funded test wallet — no mainnet wallet needed):
+
+```python
+from attestix.services.blockchain_service import BlockchainService
+
+tx = BlockchainService().anchor_audit_batch(agent_id=agent["agent_id"])
+print(tx)  # 0x...; verify on https://sepolia.basescan.org
+```
+
+Mainnet schema registration is on the [roadmap](/docs/project/roadmap); until then anchoring is testnet only and is **not** legally non-repudiable. See the [Base L2 anchor walkthrough](/docs/guides/base-l2-anchor) for the full setup.

--- a/website/content/docs/quickstart/meta.json
+++ b/website/content/docs/quickstart/meta.json
@@ -1,0 +1,16 @@
+{
+  "title": "Quickstart",
+  "pages": [
+    "index",
+    "indie-dev",
+    "fintech-compliance",
+    "healthcare-ml",
+    "enterprise-architect",
+    "grc-consultant",
+    "devtools-skeptic",
+    "web3-onchain",
+    "ai-safety-research",
+    "startup-cto",
+    "mlops-engineer"
+  ]
+}

--- a/website/content/docs/quickstart/mlops-engineer.mdx
+++ b/website/content/docs/quickstart/mlops-engineer.mdx
@@ -1,0 +1,125 @@
+---
+title: MLOps engineer — Quickstart
+description: Wire Attestix into a CI/CD pipeline so every model promotion produces a signed credential and a hash-chained audit row. Pinned versions, deterministic CLI, exit codes.
+---
+
+## You're here because…
+
+You're an MLOps engineer and the funnel evaluation flagged that your peers dropped at integration because the tool felt CLI-first / single-user — no idempotent declarative API, no Terraform / Ansible module, file-based state. This page accepts that gap and shows the realistic CI path today: a deterministic CLI plus the idempotency-aware REST surface for a CI runner. The pluggable storage backend and IaC modules are on the [roadmap](/docs/project/roadmap); what's below works against v0.4.0-rc.2 unchanged.
+
+## 60-second install
+
+Pin the version in `requirements-attestix.txt` so the CI run is reproducible:
+
+```text
+attestix==0.4.0rc2
+```
+
+Then in the CI step:
+
+```bash
+pip install --pre -r requirements-attestix.txt
+```
+
+## First 30 lines that actually do something
+
+A GitHub Actions step that, on every model promotion, registers the model lineage and issues a signed VC:
+
+```yaml
+- name: Record model lineage and issue VC
+  env:
+    ATTESTIX_KEY_PASSPHRASE: ${{ secrets.ATTESTIX_KEY_PASSPHRASE }}
+  run: |
+    python - <<'PY'
+    import json, os, sys
+    from attestix.services.identity_service import IdentityService
+    from attestix.services.provenance_service import ProvenanceService
+    from attestix.services.credential_service import CredentialService
+
+    agent_id = os.environ.get("MODEL_AGENT_ID")
+    if not agent_id:
+        agent_id = IdentityService().create_identity(
+            display_name=os.environ["MODEL_NAME"],
+            source_protocol="manual",
+            capabilities=[os.environ["MODEL_TASK"]],
+            issuer_name="VibeTensor",
+        )["agent_id"]
+        print(f"::set-output name=agent_id::{agent_id}")
+
+    ProvenanceService().record_model_lineage(
+        agent_id=agent_id,
+        base_model=os.environ["BASE_MODEL"],
+        base_model_provider=os.environ["BASE_MODEL_PROVIDER"],
+        fine_tuning_method=os.environ["FT_METHOD"],
+        evaluation_metrics=json.loads(os.environ["EVAL_METRICS"]),
+    )
+
+    vc = CredentialService().issue_credential(
+        agent_id=agent_id,
+        credential_type="ModelPromotionCredential",
+        issuer_name="VibeTensor",
+        claims={
+            "git_sha": os.environ["GITHUB_SHA"],
+            "run_id": os.environ["GITHUB_RUN_ID"],
+            "model_artifact_sha256": os.environ["MODEL_ARTIFACT_SHA"],
+            "eval_pass": True,
+        },
+    )
+    print(f"VC issued: {vc['id']}")
+    PY
+```
+
+The CLI equivalent for a tighter, side-effect-only step:
+
+```bash
+attestix init --name "$MODEL_NAME" --capabilities "$MODEL_TASK" --issuer "VibeTensor"
+attestix verify "$AGENT_ID"          # exit 0 on success, non-zero otherwise
+attestix audit "$AGENT_ID" --limit 5  # prints the latest hash-chained rows
+```
+
+## What you just got
+
+- A signed `ModelPromotionCredential` per CI run, pinning the git SHA, run id, and the model-artefact hash. The credential is verifiable offline (`attestix credential --verify <id>`).
+- A model-lineage row under the same agent DID — every promotion is a new row, not a destructive update.
+- Encrypted-at-rest signing key when `ATTESTIX_KEY_PASSPHRASE` is set (otherwise plaintext `.signing_key.json` — see the [security page](/security) for the disclosure / CVE process).
+
+## REST mode for a CI runner with idempotency
+
+If you don't want to share the `.signing_key.json` between runners, run Attestix as a service and call it over HTTP. The REST surface honours `Idempotency-Key` so retried CI runs don't duplicate identities:
+
+```bash
+attestix mcp --transport http --port 8501 &
+curl -sX POST http://localhost:8501/identities \
+  -H "Idempotency-Key: gha-${GITHUB_RUN_ID}-promote" \
+  -H "Content-Type: application/json" \
+  -d '{"display_name":"'"$MODEL_NAME"'","source_protocol":"manual","capabilities":["'$MODEL_TASK'"],"issuer_name":"VibeTensor"}'
+```
+
+## Open caveats for production MLOps
+
+The funnel evaluation specifically called these out for this persona; tracking them on the roadmap:
+
+| Concern | v0.4.0 reality |
+|---|---|
+| Declarative IaC | No Terraform / Ansible / Pulumi module today. Pinned `pip install` + a script step is the current path. |
+| Storage backend | Flat JSON files. Postgres / S3 backend is planned. |
+| Multi-runner state sharing | Run Attestix as a service (above) with persistent storage volume; sharing JSON files across runners is not supported. |
+| Secret management | `ATTESTIX_KEY_PASSPHRASE` envvar; KMS / Vault adapters planned. |
+| Anchoring | Base L2 **testnet** only. Mainnet schema registration planned. |
+
+## Next step (5 minutes)
+
+Anchor the model-promotion VC's hash to **Base Sepolia testnet** so a downstream auditor can prove the promotion existed at a block height:
+
+```python
+from attestix.services.blockchain_service import BlockchainService
+chain = BlockchainService()
+artifact_hash = chain.hash_artifact(vc)  # canonical-JSON SHA-256
+print(chain.anchor_artifact(
+    artifact_hash=artifact_hash,
+    artifact_type="credential",
+    artifact_id=vc["id"],
+))
+```
+
+See the [Base L2 anchor walkthrough](/docs/guides/base-l2-anchor) for RPC setup and gas estimates.

--- a/website/content/docs/quickstart/startup-cto.mdx
+++ b/website/content/docs/quickstart/startup-cto.mdx
@@ -1,0 +1,105 @@
+---
+title: Startup CTO — Quickstart
+description: 5-minute build-vs-buy proof — what Attestix gives you that you would otherwise build yourself for agent identity, audit, and EU AI Act paperwork.
+---
+
+## You're here because…
+
+You're a startup CTO doing a build-vs-buy on agent governance. The funnel evaluation flagged that this persona moved past install but dropped at integration — there was no path that quantified "what would I build in-house" vs "what is already here." This page is that comparison, as runnable code. Skim it as a buy-side proof-of-concept, then make the call.
+
+## 60-second install
+
+```bash
+pip install --pre attestix
+```
+
+## First 30 lines that actually do something
+
+```python
+# A single end-to-end run that exercises identity, provenance, compliance,
+# credentials, and delegation — i.e. what would otherwise be 5 separate
+# microservices in your roadmap.
+from attestix.services.identity_service import IdentityService
+from attestix.services.provenance_service import ProvenanceService
+from attestix.services.compliance_service import ComplianceService
+from attestix.services.credential_service import CredentialService
+from attestix.services.delegation_service import DelegationService
+
+orchestrator = IdentityService().create_identity(
+    display_name="ops-orchestrator",
+    source_protocol="manual",
+    capabilities=["task_routing", "delegation"],
+    issuer_name="VibeTensor",
+)["agent_id"]
+
+worker = IdentityService().create_identity(
+    display_name="ops-worker-01",
+    source_protocol="manual",
+    capabilities=["data_analysis"],
+    issuer_name="VibeTensor",
+)["agent_id"]
+
+# Capability-attenuated UCAN: orchestrator delegates a subset to worker.
+deleg = DelegationService().create_delegation(
+    issuer_agent_id=orchestrator,
+    audience_agent_id=worker,
+    capabilities=["data_analysis"],
+    expiry_hours=8,
+)
+print("delegation jti:", deleg["delegation"]["jti"])
+
+# Compliance profile + signed VC (= "show me what the regulator gets")
+ComplianceService().create_compliance_profile(
+    agent_id=orchestrator,
+    risk_category="limited",
+    provider_name="VibeTensor",
+    intended_purpose="Internal task orchestration with human approval gate",
+)
+vc = CredentialService().issue_credential(
+    agent_id=orchestrator,
+    credential_type="AgentIdentityCredential",
+    issuer_name="VibeTensor",
+    claims={"displayName": "ops-orchestrator", "complianceStatus": "limited-risk-declared"},
+)
+print("credential:", vc["id"], vc["proof"]["type"])
+
+# Hash-chained log of one operation (= "show me the audit row")
+ProvenanceService().log_action(
+    agent_id=worker,
+    action_type="inference",
+    input_summary="task_id=T-001",
+    output_summary="status=ok",
+    decision_rationale="parent_delegation=" + deleg["delegation"]["jti"],
+)
+```
+
+## What you just got (vs. what you'd otherwise build)
+
+| Capability you'd otherwise build | What Attestix shipped above |
+|---|---|
+| Ed25519 keypair gen + signing layer | `IdentityService` + `.signing_key.json` (plaintext default; passphrase-encrypted via `ATTESTIX_KEY_PASSPHRASE`) |
+| Append-only, hash-chained audit log | `ProvenanceService.log_action` |
+| W3C VC issuance + offline verification | `CredentialService.issue_credential` / `verify_credential` |
+| UCAN-style capability delegation w/ attenuation | `DelegationService.create_delegation` (parent token check is enforced) |
+| EU AI Act risk profile + Annex V declaration | `ComplianceService.create_compliance_profile` + `generate_declaration_of_conformity` |
+| MCP server exposing all of the above as tools | `attestix mcp` (47 tools, stdio or HTTP) |
+| REST surface for an internal service | `uvicorn attestix.api.main:app` (44 endpoints) |
+
+That's roughly 5 services and 3-5 engineer-months of work to get to the same surface area.
+
+## Honest things to weigh before you decide to buy
+
+- **Maturity:** beta, single maintainer, ~15 GitHub stars, no third-party security audit. The trade-off is "buy a primitive, audit it yourself" vs. "build it yourself and own the audit anyway."
+- **Storage:** flat JSON files. Production multi-tenant deployment needs the pluggable Postgres/S3 backend (planned, not in v0.4.0).
+- **Key management:** `.signing_key.json` plaintext by default. KMS / HSM / Vault integration is on the [roadmap](/docs/project/roadmap).
+- **Anchoring:** Base L2 **testnet** only in v0.4.0. Mainnet schema registration planned.
+- **License:** Apache 2.0. Source is on GitHub; fork-and-harden is a supported path.
+
+## Next step (5 minutes)
+
+If you want to see Attestix wired into a framework your team already uses, jump to the matching quickstart:
+
+- [LangChain](/docs/guides/langchain) (real callback handler)
+- [OpenAI Agents SDK](/docs/guides/openai-agents-sdk) (real MCPServerStdio)
+- [CrewAI](/docs/guides/crewai) (real MCPServerAdapter)
+- [Architecture deep-dive](/docs/guides/architecture) (service decomposition, on-disk layout)

--- a/website/content/docs/quickstart/web3-onchain.mdx
+++ b/website/content/docs/quickstart/web3-onchain.mdx
@@ -1,0 +1,104 @@
+---
+title: Web3 / on-chain dev — Quickstart
+description: Anchor an Attestix artefact to Base L2 Sepolia testnet via the Ethereum Attestation Service. Schema UID, gas estimate, faucet, on-chain verification — testnet only in v0.4.0.
+---
+
+## You're here because…
+
+You're a web3 dev evaluating the on-chain side of Attestix. The funnel evaluation flagged that the on-chain story was the loudest concrete failure for this persona: no published EAS schema UID in the docs, no on-chain verification guide, no gas estimates, no revocation flow. Anchoring was called "vaporware for production." This page is the smallest path from a clean install to a verifiable on-chain anchor — **on Base Sepolia testnet only**. Mainnet schema registration is still on the [roadmap](/docs/project/roadmap).
+
+## 60-second install
+
+```bash
+pip install --pre attestix
+```
+
+You also need:
+
+- A Base Sepolia RPC endpoint (`https://sepolia.base.org` is fine for testing).
+- A funded test wallet on Base Sepolia (~0.001 ETH from any public faucet).
+- The EAS contract address on Base Sepolia, which ships with the package.
+
+Configure once:
+
+```bash
+export BASE_RPC_URL=https://sepolia.base.org
+export EVM_PRIVATE_KEY=0x<your_testnet_key>
+```
+
+Funded the wallet at https://www.alchemy.com/faucets/base-sepolia (or any Base Sepolia faucet).
+
+## First 30 lines that actually do something
+
+```python
+from attestix.services.identity_service import IdentityService
+from attestix.services.blockchain_service import BlockchainService
+
+# 1. Make an artefact worth anchoring (a signed identity row).
+agent_id = IdentityService().create_identity(
+    display_name="onchain-test",
+    source_protocol="manual",
+    capabilities=["test"],
+    issuer_name="VibeTensor",
+)["agent_id"]
+
+# 2. Verify the chain client is configured against Base Sepolia.
+chain = BlockchainService()
+assert chain.is_configured(), \
+    "Set BASE_RPC_URL and EVM_PRIVATE_KEY. Sepolia faucet: alchemy.com/faucets/base-sepolia"
+print("wallet:", chain.wallet_address())
+
+# 3. Estimate gas first.
+estimate = chain.estimate_anchor_cost(artifact_type="identity")
+print("estimate:", estimate)  # { gas: ~48000, gas_price_wei: ..., cost_eth: ... }
+
+# 4. Build the canonical hash and anchor it on-chain via EAS.
+artifact = {"agent_id": agent_id, "kind": "identity"}
+artifact_hash = chain.hash_artifact(artifact)
+result = chain.anchor_artifact(
+    artifact_hash=artifact_hash,
+    artifact_type="identity",
+    artifact_id=agent_id,
+)
+print(result)  # { tx_hash, attestation_uid, block_number, schema_uid, ... }
+
+# 5. Verify the anchor from-scratch (anyone can run this, no Attestix server needed).
+status = chain.verify_anchor(artifact_hash=artifact_hash)
+print(status)  # { confirmed: True, attestation_uid: ..., block_number: ... }
+```
+
+## What you just got
+
+- A real EAS attestation on Base Sepolia. The transaction is on-chain at the printed `tx_hash` — view it at https://sepolia.basescan.org.
+- The Attestix EAS schema UID is computed deterministically from the schema string and persisted to `.attestix_schema_uid` on first use; the call to `_ensure_schema_registered` is idempotent and self-registers on a fresh chain.
+- A Merkle-batch path for high-volume anchoring:
+
+```python
+batch = chain.anchor_audit_batch(agent_id=agent_id)
+print(batch["batch_metadata"])  # merkle_root, entry_count, start/end_date
+```
+
+Gas cost stays roughly flat (~48k) regardless of batch size — the proof size grows as O(log n) per artefact.
+
+## What's honestly missing
+
+The funnel evaluation specifically called these out for this persona; they are still gaps in v0.4.0:
+
+| Concern | v0.4.0 reality |
+|---|---|
+| Mainnet schema UID | Not registered. Testnet only. |
+| Revocation flow | EAS supports revoke; Attestix does not yet expose a `revoke_anchor` helper. |
+| Gas data published in docs | Only the testnet `estimate_anchor_cost` output today. Mainnet numbers will land with the mainnet schema. |
+| Indexer / subgraph | None published. You query EAS directly via the contract. |
+
+## Next step (5 minutes)
+
+Verify the attestation directly on EAS (no Attestix client needed):
+
+```bash
+curl -s "https://base-sepolia.easscan.org/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ attestation(where:{id:\"<attestation_uid>\"}){ schemaId attester data }}"}'
+```
+
+Read the full walkthrough — RPC selection, key handling, schema deep-dive — in the [Base L2 anchor guide](/docs/guides/base-l2-anchor).

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -22,6 +22,17 @@ Attestix provides verifiable identity, W3C credentials, delegation chains, compl
 
 - [Overview](https://attestix.io/docs): Project overview and quick start
 - [Getting Started](https://attestix.io/docs/getting-started): Installation and first agent identity in 5 minutes
+- [Quickstart index](https://attestix.io/docs/quickstart): 10 per-ICP-persona quickstart pages, copy-paste path in 90 seconds
+- [Quickstart / Indie dev](https://attestix.io/docs/quickstart/indie-dev): LangChain RAG agent with hash-chained audit + auto-issued VC
+- [Quickstart / Fintech compliance](https://attestix.io/docs/quickstart/fintech-compliance): Trading / credit-scoring agent with Article 10/11/43 records
+- [Quickstart / Healthcare ML](https://attestix.io/docs/quickstart/healthcare-ml): Clinical decision-support agent with Annex III high-risk profile (GDPR Art. 17 only; DPDP planned for v0.5)
+- [Quickstart / Enterprise architect](https://attestix.io/docs/quickstart/enterprise-architect): Self-hosted REST + MCP service with tenant context and idempotency
+- [Quickstart / GRC consultant](https://attestix.io/docs/quickstart/grc-consultant): Annex IV / Annex V evidence bundle for a client; de-conflates integrity vs. conformity
+- [Quickstart / DevTools skeptic](https://attestix.io/docs/quickstart/devtools-skeptic): 60-second smoke test that the package imports cleanly from a fresh venv
+- [Quickstart / Web3 on-chain](https://attestix.io/docs/quickstart/web3-onchain): EAS anchor on Base Sepolia testnet with schema UID + gas estimate
+- [Quickstart / AI safety research](https://attestix.io/docs/quickstart/ai-safety-research): Signed, hash-chained agent telemetry from an eval run
+- [Quickstart / Startup CTO](https://attestix.io/docs/quickstart/startup-cto): 5-minute build-vs-buy proof across identity + audit + delegation + compliance
+- [Quickstart / MLOps engineer](https://attestix.io/docs/quickstart/mlops-engineer): Pinned-version CI step that records model lineage and issues a promotion VC
 - [Examples](https://attestix.io/docs/examples): Runnable code examples for all modules
 - [EU AI Act Compliance](https://attestix.io/docs/guides/eu-ai-act-compliance): Full compliance workflow with checklists
 - [EU Compliance Walkthrough](https://attestix.io/docs/guides/eu-compliance-walkthrough): Step-by-step pipeline


### PR DESCRIPTION
## What
**10 per-ICP-persona quickstart pages** at `attestix.io/docs/quickstart/{slug}` + a routing index. Addresses the funnel-eval's #2 dropout point (developers bouncing at "what code do I actually write"). Persona list **followed `paper/internal/icp-funnel-eval-2026-05-28.md`** (buyer-shaped) rather than my framework-shaped defaults — dropped the two non-coding personas (security/pentester, procurement) to honour the 10-page target.

### Pages shipped
| Slug | Persona | Headline code path |
|---|---|---|
| `indie-dev` | Indie AI-agent dev | LangChain `AttestixCallback` + `anchor_audit_batch` |
| `fintech-compliance` | Fintech compliance eng | `record_training_data` → `record_conformity_assessment` → `generate_declaration_of_conformity` |
| `healthcare-ml` | Healthcare ML lead | `record_training_data` + `record_model_lineage` + GDPR Art 17 revoke |
| `enterprise-architect` | Platform architect | REST + `Idempotency-Key` + `X-Tenant-Id` |
| `grc-consultant` | EU AI Act / GRC consultant | full `quickstart.py` flow + `create_verifiable_presentation` |
| `devtools-skeptic` | Senior DevTools/DX skeptic | 30-line smoke test + `-W error::DeprecationWarning` |
| `web3-onchain` | Web3 / blockchain dev | `BlockchainService.{hash_artifact, anchor_artifact, verify_anchor, anchor_audit_batch}` |
| `ai-safety-research` | Academic AI-safety researcher | `record_model_lineage` + `verify_credential_external` |
| `startup-cto` | Startup CTO | comparison page: delegation chain + compliance profile + VC issuance |
| `mlops-engineer` | MLOps engineer | GitHub Actions step + CLI (`init`/`verify`/`audit`) |

Plus `index.mdx` routing + Fumadocs `meta.json`. CrewAI/OpenAI-Agents SDK users routed from the index to the existing `/docs/guides/{langchain,openai-agents-sdk,crewai}` deep dives.

### Honesty rules applied (per the funnel eval)
- Base L2 anchoring is **Sepolia testnet only**; mainnet schema registration explicitly called out as planned.
- DPDP coverage marked "referenced but not implemented in v0.4.0 — planned for v0.5".
- LangChain / OpenAI Agents SDK / CrewAI flagged as **real** integrations; Dify / ADK / SK / Strands as **example-only**.
- Maturity stated honestly (beta, single maintainer, no third-party security audit) on every page.

### Real surfaces cross-checked
Every page's APIs were verified against the actual modules — `attestix.integrations.langchain.AttestixCallback`, `IdentityService.create_identity`, `BlockchainService.{is_configured, wallet_address, estimate_anchor_cost, hash_artifact, anchor_artifact, verify_anchor, anchor_audit_batch}`, `ProvenanceService.{record_training_data, record_model_lineage, log_action, get_provenance}`, `CredentialService.{issue_credential, verify_credential, verify_credential_external, create_verifiable_presentation}`, `ComplianceService.{create_compliance_profile, record_conformity_assessment, generate_declaration_of_conformity}`, `DelegationService.create_delegation`.

## Test plan
- `npx next build` → **71/71 static pages**, 0 warnings, all 10 quickstart HTML files generated under `out/docs/quickstart/`.
- `npx tsc --noEmit` → 0 output.
- All `(/docs/…)` internal links resolved.

## Found-while-shipping (separate follow-up patch)
`website/content/docs/guides/base-l2-anchor.mdx` calls `svc.anchor_identity(...)`, `svc.anchor_credential(...)`, `svc.balance()` — those are **MCP-tool / REST shapes, not `BlockchainService` methods**. Service-layer equivalents are `anchor_artifact(artifact_hash, artifact_type, artifact_id)` + `wallet_address()`. Did not fix here (out of scope).
