### PR TITLE
feat(cli,portability): attestix export — produce M6-compatible bundles (closes symmetric portability)

### DIFF
--- a/attestix/cli.py
+++ b/attestix/cli.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import sys
 from importlib.metadata import version as pkg_version, PackageNotFoundError
+from pathlib import Path
 
 import click
 
@@ -597,6 +598,98 @@ def import_cmd(bundle_path, force, workspace, verify_only):
     click.echo("  attestix list                # see imported identities")
     click.echo("  attestix audit <agent_id>    # verify the imported audit chain")
     click.echo("  attestix status              # confirm aggregate counts")
+
+
+# ---------------------------------------------------------------------------
+# attestix export (OSS portability bundle export)
+# ---------------------------------------------------------------------------
+
+@cli.command(name="export")
+@click.argument("output_path", type=click.Path(dir_okay=False, writable=True))
+@click.option(
+    "--workspace",
+    default=None,
+    help="Only export rows tagged with this local workspace tenant (default: every row).",
+)
+@click.option(
+    "--include-anchors/--no-include-anchors",
+    default=True,
+    show_default=True,
+    help="Include the anchors collection in the bundle.",
+)
+@click.option(
+    "--include-audit/--no-include-audit",
+    default=True,
+    show_default=True,
+    help="Include the audit_events collection in the bundle.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite output_path if it already exists.",
+)
+@click.option(
+    "--no-pretty",
+    is_flag=True,
+    help="Suppress the per-table progress lines (JSON-only summary at the end).",
+)
+def export_cmd(output_path, workspace, include_anchors, include_audit, force, no_pretty):
+    """Export local OSS state as an Attestix portability bundle (M6-compatible).
+
+    Writes a USTAR + gzip tarball at OUTPUT_PATH containing one JCS-canonical
+    JSONL file per table, a ``manifest.json``, and a side-car
+    ``manifest.sha256`` — the exact format the cloud worker emits and the
+    importer (``attestix import``) accepts.
+
+    The output is byte-stable across re-runs against the same OSS state:
+    members are sorted alphabetically, tar mtimes are pinned to 0, and the
+    gzip header carries mtime=0. Two consecutive exports of the same data
+    produce identical bytes — useful for diffing audit-chain drift across
+    backups.
+    """
+    from attestix.portability import BundleWriteError, write_bundle
+
+    out = Path(output_path)
+    if out.exists() and not force:
+        _error(
+            f"refusing to overwrite existing file {out!s}. "
+            f"Re-run with --force to replace it."
+        )
+
+    if not no_pretty:
+        _header(f"Attestix export → {out}")
+        if workspace:
+            click.echo(f"  Workspace filter : {workspace}")
+        else:
+            click.echo(f"  Workspace filter : (every tenant)")
+        click.echo(f"  Include anchors  : {include_anchors}")
+        click.echo(f"  Include audit    : {include_audit}")
+        click.echo()
+
+    try:
+        result = write_bundle(
+            out,
+            workspace=workspace,
+            include_anchors=include_anchors,
+            include_audit=include_audit,
+        )
+    except BundleWriteError as e:
+        _error(str(e))
+
+    if not no_pretty:
+        _header("Tables")
+        for t in result.tables:
+            check = click.style("OK", fg="green")
+            label = f"{t.name:<24}"
+            sha_short = t.sha256[:12] + "…"
+            click.echo(
+                f"  [{check}] {label} {t.row_count} rows  sha256:{sha_short}"
+            )
+        click.echo()
+
+    _success(
+        f"wrote {result.path}  {result.bytes} bytes  manifest_sha256={result.manifest_sha256}"
+    )
 
 
 if __name__ == "__main__":

--- a/attestix/portability/__init__.py
+++ b/attestix/portability/__init__.py
@@ -37,18 +37,32 @@ from attestix.portability.importer import (
     Importer,
     LocalDataExistsError,
 )
+from attestix.portability.bundle_writer import (
+    BundleResult,
+    BundleWriteError,
+    EXPORT_PLAN,
+    TableResult,
+    TableSpec,
+    write_bundle,
+)
 
 __all__ = [
     "BUNDLE_FORMAT_URL",
     "Bundle",
     "BundleError",
     "BundleImportError",
+    "BundleResult",
     "BundleSchemaTooNewError",
     "BundleVerifyError",
+    "BundleWriteError",
+    "EXPORT_PLAN",
     "Importer",
     "ImportResult",
     "LocalDataExistsError",
     "SUPPORTED_DB_MIGRATION_MAX",
     "SUPPORTED_MANIFEST_VERSION",
+    "TableResult",
+    "TableSpec",
     "read_bundle",
+    "write_bundle",
 ]

--- a/attestix/portability/bundle_writer.py
+++ b/attestix/portability/bundle_writer.py
@@ -1,0 +1,609 @@
+"""Write Attestix portability bundles (the OSS-side symmetric counterpart).
+
+The :func:`write_bundle` helper is the inverse of
+:mod:`attestix.portability.importer`: it reads every OSS-side collection through
+the existing :class:`~attestix.storage.Repository` boundary, projects each row
+into the cloud wire-format shape the importer expects, JCS-canonicalises every
+row, sha-256s every table, and emits a USTAR + gzip tarball whose layout matches
+``apps/workers/ts/src/exports.ts`` byte-for-byte.
+
+Why a separate writer and not a method on the Repository? Because the cloud
+exporter is the authoritative wire-format definition (the spec page at
+``https://attestix.io/spec/bundle/v1`` describes its output); the OSS exporter
+mirrors that spec so cloud bundles and OSS bundles are interchangeable. Pinning
+that mirror to one module keeps the wire-format coupling auditable in code
+review — change the cloud exporter and you must change this file in lock-step.
+
+JCS canonicaliser
+-----------------
+
+The writer reuses :func:`attestix.auth.crypto.canonicalize_json` exactly. The
+constitution forbids a second canonicaliser anywhere in the codebase, so the
+manifest's sha-256 (computed over the canonical manifest bytes with no
+``sha256`` field of its own) and every table's sha-256 (computed over the
+JSONL bytes) both flow through the same routine the importer reads back.
+
+Determinism
+-----------
+
+When ``deterministic=True`` (the default), the tarball is byte-stable across
+runs against the same OSS state:
+
+* Members are sorted alphabetically — matches the cloud worker's
+  ``sort()`` over its staging directory listing and the fixture generator.
+* USTAR ``mtime`` is pinned to ``0``.
+* The gzip header is written with ``mtime=0`` (the cloud worker leaves the
+  default ``Date.now()``, but the fixture generator pins ``mtime=0`` and that
+  is the value the OSS round-trip suite expects).
+* Row order inside each table is the order returned by the Repository's
+  ``list`` for that collection. The order is itself byte-stable for the
+  default :class:`FileRepository` (rows are appended; we never re-sort), so
+  two consecutive exports of the same data produce identical bytes.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+import tarfile
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+from attestix import __version__ as ATTESTIX_VERSION
+from attestix.auth.crypto import canonicalize_json
+from attestix.portability.bundle_reader import (
+    BUNDLE_FORMAT_URL,
+    SUPPORTED_DB_MIGRATION_MAX,
+    SUPPORTED_MANIFEST_VERSION,
+)
+from attestix.storage import Repository, default_repository
+from attestix.storage.repository import DEFAULT_TENANT
+
+
+#: The cloud-equivalent core_version stamp. Mirrors the cloud worker's
+#: ``CORE_VERSION_PIN`` format ("attestix==<semver>") so a reader cannot tell a
+#: well-formed OSS export apart from a well-formed cloud export by version
+#: shape alone — both round-trip through the same import path.
+CORE_VERSION = f"attestix=={ATTESTIX_VERSION}"
+
+
+class BundleWriteError(Exception):
+    """Raised for a problem writing a portability bundle."""
+
+
+# ---------------------------------------------------------------------------
+# Row projectors — OSS row shape → cloud wire-format shape
+# ---------------------------------------------------------------------------
+#
+# Each projector mirrors the inverse of the importer's row mapper. When the OSS
+# row carries `_cloud_id` / `_cloud_workspace_id` metadata (left there by a
+# prior import) we re-use those values so the round-trip is idempotent — a
+# re-export after a cloud→OSS→export cycle preserves the same cloud UUIDs and
+# workspace bindings.
+
+
+#: A fixed namespace UUID for synthesising cloud-shaped IDs deterministically.
+#: Generated once with ``uuid.uuid4()`` and frozen here so two consecutive
+#: exports of the same OSS row produce the same synthetic cloud UUID — a
+#: prerequisite for the byte-identical re-export guarantee.
+_CLOUD_ID_NAMESPACE = uuid.UUID("6b1c1e3e-1f0c-4f0d-9b6f-7a6e1c3f5d8a")
+
+
+def _gen_cloud_id(*parts: str) -> str:
+    """Produce a UUID5 deterministically from ``parts``.
+
+    The cloud worker writes a real Postgres UUID for the ``id`` column on every
+    row it exports. For OSS rows that never round-tripped through the cloud
+    there is no native UUID, so we synthesise a stable one by hashing the row's
+    semantic identifier through UUID5. Identical OSS state → identical
+    synthesised UUIDs → byte-identical re-exports.
+    """
+    seed = "|".join(p or "" for p in parts)
+    return str(uuid.uuid5(_CLOUD_ID_NAMESPACE, seed))
+
+
+def _drop_tenant(row: dict) -> dict:
+    """Return ``row`` without the Repository-injected ``tenant_id`` tag."""
+    return {k: v for k, v in row.items() if k != "tenant_id"}
+
+
+def _row_identity_to_cloud(oss: dict, *, workspace_id: str) -> dict:
+    """Project an OSS identity row into the cloud ``identities`` wire shape.
+
+    Inverse of :func:`attestix.portability.importer._row_identity`.
+    """
+    cloud_id = oss.get("_cloud_id") or _gen_cloud_id("identity", oss.get("agent_id", ""))
+    cloud_ws = oss.get("_cloud_workspace_id") or workspace_id
+    issuer = oss.get("issuer") or {}
+    did = oss.get("did") or (issuer.get("did") if isinstance(issuer, dict) else None)
+    name = oss.get("display_name") or (
+        issuer.get("name") if isinstance(issuer, dict) else None
+    ) or oss.get("agent_id")
+    revoked = bool(oss.get("revoked"))
+    return {
+        "id": cloud_id,
+        "workspace_id": cloud_ws,
+        "core_object_ref": oss.get("agent_id"),
+        "did": did,
+        "did_method": did.split(":", 2)[1] if did and did.startswith("did:") else None,
+        "did_document": oss.get("did_document"),
+        "name": name,
+        "signing_key_kms_ref": None,
+        "status": "revoked" if revoked else "active",
+        "created_at": oss.get("created_at"),
+        "revoked_at": oss.get("revoked_at"),
+        "revocation_reason": oss.get("revocation_reason"),
+    }
+
+
+def _row_credential_to_cloud(oss: dict, *, workspace_id: str) -> dict:
+    """Project an OSS credential row (the VC body) into the cloud ``credentials`` wire shape."""
+    cloud_id = oss.get("_cloud_id") or _gen_cloud_id("credential", oss.get("id", ""))
+    cloud_ws = oss.get("_cloud_workspace_id") or workspace_id
+    # The OSS row IS the VC body itself — strip OSS-only annotations before
+    # nesting it under the cloud row's `credential` column.
+    body = {
+        k: v
+        for k, v in oss.items()
+        if k not in {"_cloud_id", "_cloud_workspace_id", "tenant_id"}
+    }
+    return {
+        "id": cloud_id,
+        "workspace_id": cloud_ws,
+        "credential": body,
+    }
+
+
+def _row_compliance_profile_to_cloud(oss: dict, *, workspace_id: str) -> dict:
+    """Project an OSS compliance profile into the cloud ``compliance_profiles`` shape."""
+    cloud_id = oss.get("_cloud_id") or _gen_cloud_id("compliance_profile", oss.get("profile_id", ""))
+    cloud_ws = oss.get("_cloud_workspace_id") or workspace_id
+    body = {
+        k: v
+        for k, v in oss.items()
+        if k not in {"_cloud_id", "_cloud_workspace_id", "tenant_id"}
+    }
+    return {
+        "id": cloud_id,
+        "workspace_id": cloud_ws,
+        "profile": body,
+    }
+
+
+def _row_conformity_assessment_to_cloud(oss: dict, *, workspace_id: str) -> dict:
+    """Project an OSS conformity assessment into the cloud ``conformity_assessments`` shape."""
+    cloud_id = oss.get("_cloud_id") or _gen_cloud_id(
+        "conformity_assessment", oss.get("assessment_id", "")
+    )
+    cloud_ws = oss.get("_cloud_workspace_id") or workspace_id
+    body = {
+        k: v
+        for k, v in oss.items()
+        if k not in {"_cloud_id", "_cloud_workspace_id", "tenant_id"}
+    }
+    return {
+        "id": cloud_id,
+        "workspace_id": cloud_ws,
+        "assessment": body,
+    }
+
+
+def _row_audit_event_to_cloud(oss: dict, *, workspace_id: str) -> dict:
+    """Project an OSS audit_event into the cloud ``audit_events`` wire shape.
+
+    Chain-relevant fields (``event_id``, ``actor``, ``action``, ``target_id``,
+    ``target_collection``, ``occurred_at``, ``change_digest``, ``prev_hash``,
+    ``chain_hash``) are passed through verbatim — the chain_hash was computed
+    over those fields' JCS canonical form, so any mutation would break the
+    importer's :func:`verify_chain` round-trip. The OSS ``tenant_id`` field is
+    also preserved verbatim because it participates in the chain_hash body; the
+    cloud surrogate ``workspace_id`` is recorded separately for cloud-side
+    re-binding (the importer drops it).
+
+    Cloud-only surrogate fields (``id``, ``occurred_at_month``, ``anchor_id``,
+    ``retention_days``, ``created_at``) are synthesised from the OSS row when
+    a prior import did not stamp them as ``_cloud_*`` metadata.
+    """
+    cloud_id = oss.get("_cloud_id") or _gen_cloud_id("audit_event", oss.get("event_id", ""))
+    cloud_ws = oss.get("_cloud_workspace_id") or workspace_id
+    anchor_id = oss.get("_cloud_anchor_id")
+    # `occurred_at_month` is a YYYY-MM-DD bucket the cloud uses for retention;
+    # we derive it from the chain field so re-imports keep the partitioning.
+    occurred_at = oss.get("occurred_at", "")
+    month_bucket = occurred_at[:10] if len(occurred_at) >= 10 else occurred_at
+    return {
+        "id": cloud_id,
+        "workspace_id": cloud_ws,
+        "occurred_at_month": month_bucket,
+        "anchor_id": anchor_id,
+        "retention_days": None,
+        "created_at": occurred_at,
+        # Chain fields — preserved verbatim.
+        "event_id": oss["event_id"],
+        "tenant_id": oss.get("tenant_id"),
+        "actor": oss["actor"],
+        "action": oss["action"],
+        "target_id": oss["target_id"],
+        "target_collection": oss["target_collection"],
+        "occurred_at": oss["occurred_at"],
+        "change_digest": oss["change_digest"],
+        "prev_hash": oss["prev_hash"],
+        "chain_hash": oss["chain_hash"],
+    }
+
+
+def _row_anchor_to_cloud(oss: dict, *, workspace_id: str) -> dict:
+    """Project an OSS anchor row into the cloud ``anchors`` wire shape."""
+    cloud_id = oss.get("_cloud_id") or _gen_cloud_id("anchor", oss.get("anchor_id", ""))
+    cloud_ws = oss.get("_cloud_workspace_id") or workspace_id
+    body = {
+        k: v
+        for k, v in oss.items()
+        if k not in {"_cloud_id", "_cloud_workspace_id", "tenant_id"}
+    }
+    return {
+        "id": cloud_id,
+        "workspace_id": cloud_ws,
+        "anchor": body,
+    }
+
+
+# ---------------------------------------------------------------------------
+# EXPORT_PLAN — the inverse of IMPORT_PLAN
+# ---------------------------------------------------------------------------
+#
+# Tuple shape:
+#   (bundle_table_name, oss_collection, id_field, list_key_in_document, projector)
+#
+# ``oss_collection`` is the FileRepository collection name (see _COLLECTIONS in
+# file_repository.py). ``list_key_in_document`` is the key under which rows live
+# in the collection's JSON document — for ``compliance`` we read both
+# ``profiles`` and ``assessments`` from the same document, hence two entries.
+# ``id_field`` is the per-collection primary-key field the Repository uses.
+#
+# Order MUST match the cloud worker's ``EXPORT_TABLE_SPECS`` so the manifest
+# tables array and the on-disk member order agree byte-for-byte across the two
+# implementations.
+
+ProjectorFn = Callable[[dict, str], dict]
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    """One row of EXPORT_PLAN."""
+
+    name: str  # bundle table name (e.g. "audit_events")
+    oss_collection: Optional[str]  # FileRepository collection, None for cloud-only
+    id_field: str
+    list_key: str
+    projector: Optional[ProjectorFn]
+
+
+EXPORT_PLAN: List[TableSpec] = [
+    TableSpec("identities", "identities", "agent_id", "agents", _row_identity_to_cloud),
+    # Cloud-only — emitted as an empty JSONL so the OSS bundle has the same
+    # member set as a cloud bundle (the importer skips these on read).
+    TableSpec("key_references", None, "id", "", None),
+    TableSpec("credentials", "credentials", "id", "credentials", _row_credential_to_cloud),
+    TableSpec("credential_schemas", None, "id", "", None),
+    TableSpec("memberships", None, "id", "", None),
+    TableSpec("team_invites", None, "id", "", None),
+    TableSpec("subscriptions", None, "id", "", None),
+    TableSpec(
+        "compliance_profiles",
+        "compliance",
+        "profile_id",
+        "profiles",
+        _row_compliance_profile_to_cloud,
+    ),
+    TableSpec(
+        "conformity_assessments",
+        "compliance",
+        "assessment_id",
+        "assessments",
+        _row_conformity_assessment_to_cloud,
+    ),
+    TableSpec("agent_dependencies", None, "id", "", None),
+    TableSpec("audit_events", "audit", "event_id", "events", _row_audit_event_to_cloud),
+    TableSpec("anchors", "anchors", "anchor_id", "anchors", _row_anchor_to_cloud),
+    TableSpec("webhook_endpoints", None, "id", "", None),
+]
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TableResult:
+    """Per-table outcome of one export run."""
+
+    name: str
+    row_count: int
+    bytes: int
+    sha256: str
+
+
+@dataclass
+class BundleResult:
+    """Aggregate outcome of one export run."""
+
+    path: Path
+    bytes: int
+    manifest_sha256: str
+    tables: List[TableResult] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Implementation
+# ---------------------------------------------------------------------------
+
+
+def _jsonl_canonical(rows: List[dict]) -> bytes:
+    """Serialise rows as JCS-canonical JSONL (one row per line, trailing \\n).
+
+    Mirrors :func:`tests.fixtures.bundles.generate_sample_bundle._jsonl_canonical`
+    exactly — the cloud worker's output uses the same pattern and the reader
+    splits on ``\\n`` skipping empty tail lines, so an empty table writes zero
+    bytes (no trailing newline).
+    """
+    if not rows:
+        return b""
+    lines = [canonicalize_json(r).decode("utf-8") for r in rows]
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _sha256_hex(body: bytes) -> str:
+    return hashlib.sha256(body).hexdigest()
+
+
+def _infer_workspace_slug(repo: Repository) -> str:
+    """Infer the bundle's workspace slug from the local audit chain.
+
+    Returns the single tenant_id every audit event was chained against, or
+    :data:`DEFAULT_TENANT` if no audit events exist. Raises if events come from
+    multiple tenants — the bundle's manifest carries one workspace slug, so a
+    multi-tenant install must either pass ``--workspace`` to pick one or run
+    one export per tenant.
+    """
+    if not hasattr(repo, "load_document"):
+        return DEFAULT_TENANT
+    doc = repo.load_document("audit")
+    events = doc.get("events", []) or []
+    tenants = {ev.get("tenant_id", DEFAULT_TENANT) for ev in events}
+    if not tenants:
+        return DEFAULT_TENANT
+    if len(tenants) == 1:
+        return next(iter(tenants))
+    raise BundleWriteError(
+        "audit_events span multiple tenants "
+        f"({sorted(tenants)!r}); pass --workspace <tenant> to pick one. The "
+        "bundle's workspace slug must match the audit chain's tenant so the "
+        "importer can re-verify the chain end-to-end."
+    )
+
+
+def _list_rows(
+    repo: Repository, oss_collection: str, list_key: str, *, workspace: Optional[str]
+) -> List[dict]:
+    """Read every row in an OSS collection.
+
+    Uses the Repository's ``load_document`` to read all rows regardless of
+    tenant, since portability is a workspace-level concern, not a per-tenant
+    one. If ``workspace`` is set, only rows tagged with that ``tenant_id`` are
+    returned — the FileRepository tags every row with its tenant on create, so
+    rows created under the default tenant carry ``tenant_id == "default"``.
+
+    The list_key lookup mirrors :mod:`attestix.storage.file_repository._COLLECTIONS`:
+    every Repository document has one top-level key holding the row list, plus
+    optional sibling lists (e.g. ``compliance`` carries ``profiles`` /
+    ``assessments`` / ``declarations`` in one file).
+    """
+    if not hasattr(repo, "load_document"):
+        # A Repository without load_document (e.g. a custom backend) still
+        # supports list(); fall back to that, scoped by the requested workspace
+        # tenant or the default tenant.
+        tenant = workspace or DEFAULT_TENANT
+        return repo.list(oss_collection, tenant_id=tenant)
+    doc = repo.load_document(oss_collection)
+    rows = list(doc.get(list_key, []) or [])
+    if workspace is not None:
+        rows = [r for r in rows if r.get("tenant_id", DEFAULT_TENANT) == workspace]
+    return rows
+
+
+def _build_tar(
+    members: List[Tuple[str, bytes]],
+    *,
+    deterministic: bool,
+) -> bytes:
+    """Assemble the tarball bytes from ``(name, body)`` pairs.
+
+    ``members`` is consumed in the order provided; callers must pre-sort.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+        for name, data in members:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mode = 0o644
+            if deterministic:
+                info.mtime = 0
+                info.uid = 0
+                info.gid = 0
+                info.uname = ""
+                info.gname = ""
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _gzip_bytes(tar_bytes: bytes, *, deterministic: bool) -> bytes:
+    """Gzip ``tar_bytes``. With ``deterministic=True`` the gzip header carries ``mtime=0``."""
+    out = io.BytesIO()
+    mtime = 0 if deterministic else None
+    with gzip.GzipFile(filename="", fileobj=out, mode="wb", mtime=mtime) as gz:
+        gz.write(tar_bytes)
+    return out.getvalue()
+
+
+def write_bundle(
+    output_path: Path,
+    *,
+    workspace: Optional[str] = None,
+    include_anchors: bool = True,
+    include_audit: bool = True,
+    deterministic: bool = True,
+    repository: Optional[Repository] = None,
+    now: Optional[datetime] = None,
+) -> BundleResult:
+    """Write a portability bundle for the local OSS instance.
+
+    Args:
+        output_path: Where to write the ``.tar.gz``. Parent directories are
+            created if missing.
+        workspace: If set, only rows tagged ``tenant_id == workspace`` are
+            exported. The bundle's ``workspace.slug`` is set to this value (or
+            ``"local"`` when ``None``).
+        include_anchors: When ``False`` the ``anchors`` table is emitted with
+            zero rows but is still present in the manifest (the reader is
+            tolerant of zero-row tables).
+        include_audit: When ``False`` the ``audit_events`` table is emitted
+            with zero rows. The cloud exporter has the same flag at the export
+            request layer; we expose it here for parity.
+        deterministic: Byte-stable tar + gzip output (mtime pinned to 0, member
+            order alphabetical). Tests that byte-compare two consecutive
+            exports require this.
+        repository: Override the default file-backed Repository (used by
+            tests). Defaults to :func:`attestix.storage.default_repository`.
+        now: Override the export timestamp (used by tests for byte stability).
+
+    Returns:
+        :class:`BundleResult` with the on-disk size, the manifest sha-256, and
+        per-table metadata.
+
+    Raises:
+        BundleWriteError: For any structural problem (Repository unavailable,
+            row projection failure, etc.).
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    repo = repository or default_repository()
+
+    # The workspace slug stamped into the manifest MUST match the tenant_id the
+    # exported audit events were chained against. The importer projects
+    # audit_events back using ``bundle.workspace.slug`` as the row's tenant_id,
+    # and the chain_hash includes tenant_id in its JCS-canonical body — so a
+    # workspace slug that differs from the audit events' tenant breaks chain
+    # re-verification on import.
+    #
+    # Resolution order:
+    #   1. Explicit ``workspace`` argument (the user told us which tenant).
+    #   2. Inspect the audit_events collection: if every event shares one
+    #      tenant, use it.
+    #   3. Otherwise fall back to ``DEFAULT_TENANT`` ("default"), which is the
+    #      tenant every v0.3.0 / single-tenant self-host install writes under.
+    workspace_slug = workspace or _infer_workspace_slug(repo)
+    workspace_id = workspace or workspace_slug
+    exported_at = (now or datetime.now(timezone.utc)).strftime(
+        "%Y-%m-%dT%H:%M:%S.000Z"
+    )
+
+    # ---- Stage 1: build every table body + manifest entry ------------------
+    table_entries: List[dict] = []
+    table_bodies: Dict[str, bytes] = {}
+    table_results: List[TableResult] = []
+
+    for spec in EXPORT_PLAN:
+        if spec.oss_collection is None or spec.projector is None:
+            # Cloud-only table — emit an empty JSONL so the bundle's member set
+            # mirrors a cloud-side export. The reader is happy with row_count=0.
+            rows_cloud: List[dict] = []
+        elif spec.name == "anchors" and not include_anchors:
+            rows_cloud = []
+        elif spec.name == "audit_events" and not include_audit:
+            rows_cloud = []
+        else:
+            try:
+                oss_rows = _list_rows(
+                    repo, spec.oss_collection, spec.list_key, workspace=workspace
+                )
+            except Exception as e:  # noqa: BLE001 — surface storage errors verbosely
+                raise BundleWriteError(
+                    f"failed to read OSS collection {spec.oss_collection!r} "
+                    f"for table {spec.name!r}: {e}"
+                ) from e
+            try:
+                rows_cloud = [
+                    spec.projector(_drop_tenant(r), workspace_id=workspace_id)
+                    for r in oss_rows
+                ]
+            except Exception as e:  # noqa: BLE001
+                raise BundleWriteError(
+                    f"row projection failed for table {spec.name!r}: {e}"
+                ) from e
+
+        body = _jsonl_canonical(rows_cloud)
+        sha = _sha256_hex(body)
+        member = f"{spec.name}.jsonl"
+        table_bodies[member] = body
+        table_entries.append(
+            {
+                "name": spec.name,
+                "format": "jsonl",
+                "row_count": len(rows_cloud),
+                "bytes": len(body),
+                "sha256": sha,
+            }
+        )
+        table_results.append(
+            TableResult(name=spec.name, row_count=len(rows_cloud), bytes=len(body), sha256=sha)
+        )
+
+    # ---- Stage 2: build manifest + compute its sha-256 ---------------------
+    manifest = {
+        "manifest_version": SUPPORTED_MANIFEST_VERSION,
+        "attestix_bundle_format": BUNDLE_FORMAT_URL,
+        "workspace": {
+            "id": workspace_id,
+            "slug": workspace_slug,
+            "region": "local",
+            "data_residency": "self-host",
+        },
+        "exported_at": exported_at,
+        "exported_by": {"user_id": "local", "email": "self-host@local"},
+        "tables": table_entries,
+        "core_version": CORE_VERSION,
+        "schemas": {"db_migration_max": SUPPORTED_DB_MIGRATION_MAX},
+        "notes": ["format=jsonl", "exporter=oss"],
+    }
+    manifest_canonical = canonicalize_json(manifest)
+    manifest_sha = _sha256_hex(manifest_canonical)
+
+    # ---- Stage 3: assemble tar + gzip (alphabetical member order) ----------
+    members: List[Tuple[str, bytes]] = list(table_bodies.items())
+    members.append(("manifest.json", manifest_canonical))
+    members.append(("manifest.sha256", (manifest_sha + "\n").encode("utf-8")))
+    # Determinism: alphabetical order across every member. Without sorting, the
+    # tar's member order depends on Python dict insertion order — stable in
+    # CPython 3.7+, but the cloud worker sorts explicitly and the OSS round-
+    # trip suite byte-compares against that ordering.
+    members.sort(key=lambda kv: kv[0])
+
+    tar_bytes = _build_tar(members, deterministic=deterministic)
+    gz_bytes = _gzip_bytes(tar_bytes, deterministic=deterministic)
+
+    output_path.write_bytes(gz_bytes)
+
+    return BundleResult(
+        path=output_path,
+        bytes=len(gz_bytes),
+        manifest_sha256=manifest_sha,
+        tables=table_results,
+    )

--- a/tests/cli/test_export_command.py
+++ b/tests/cli/test_export_command.py
@@ -1,0 +1,109 @@
+"""CLI smoke tests for ``attestix export`` (OSS portability bundle write).
+
+Drives the Click command through :class:`CliRunner` against the tmp-redirected
+storage directory (``tmp_attestix`` autouse fixture in ``tests/conftest.py``).
+
+Cases:
+
+* Default invocation on an empty store writes a valid bundle and exits 0.
+* Refusing to overwrite an existing target without ``--force``.
+* Round-trip: ``attestix export`` → ``attestix import --verify-only`` exits 0.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from attestix.cli import cli
+from attestix.portability import read_bundle
+from attestix.services.identity_service import IdentityService
+
+
+def _run(args):
+    try:
+        runner = CliRunner(mix_stderr=False)  # Click <8.3
+    except TypeError:
+        runner = CliRunner()
+    return runner.invoke(cli, args, catch_exceptions=False)
+
+
+def _combined_output(result) -> str:
+    out = result.output or ""
+    try:
+        err = result.stderr or ""
+    except (AttributeError, ValueError):
+        err = ""
+    return out + err
+
+
+def test_export_writes_file_and_exits_zero(tmp_path):
+    out = tmp_path / "export.tar.gz"
+    result = _run(["export", str(out)])
+    assert result.exit_code == 0, _combined_output(result)
+    assert out.exists()
+    assert out.stat().st_size > 0
+    # The success line carries the manifest sha.
+    assert "manifest_sha256=" in result.output
+
+
+def test_export_refuses_overwrite_without_force(tmp_path):
+    out = tmp_path / "export.tar.gz"
+    out.write_bytes(b"already here")
+
+    result = _run(["export", str(out)])
+    assert result.exit_code != 0
+    combined = _combined_output(result)
+    assert "--force" in combined
+    # File body was not touched.
+    assert out.read_bytes() == b"already here"
+
+
+def test_export_force_overwrites_existing_file(tmp_path):
+    out = tmp_path / "export.tar.gz"
+    out.write_bytes(b"already here")
+
+    result = _run(["export", str(out), "--force"])
+    assert result.exit_code == 0, _combined_output(result)
+    # The new bytes are a gzipped tar, not the placeholder.
+    assert out.read_bytes() != b"already here"
+    assert out.read_bytes()[:2] == b"\x1f\x8b"  # gzip magic
+
+
+def test_export_then_verify_only_import_round_trip(tmp_path):
+    # Seed at least one identity so the bundle carries real data.
+    svc = IdentityService()
+    svc.create_identity(
+        display_name="CLI Round-Trip",
+        source_protocol="manual",
+        description="Round-trip seed",
+    )
+
+    out = tmp_path / "round-trip.tar.gz"
+    export_result = _run(["export", str(out)])
+    assert export_result.exit_code == 0, _combined_output(export_result)
+
+    # The bundle's identities table is non-empty.
+    bundle = read_bundle(out)
+    assert bundle.tables["identities"].row_count >= 1
+
+    # Now run `attestix import --verify-only` against the bundle we just wrote.
+    import_result = _run(["import", str(out), "--verify-only"])
+    assert import_result.exit_code == 0, _combined_output(import_result)
+    assert "Verify-only mode" in import_result.output
+
+
+def test_export_help_listed_in_main():
+    result = _run(["--help"])
+    assert result.exit_code == 0
+    assert "export" in result.output
+
+
+def test_no_pretty_suppresses_per_table_progress(tmp_path):
+    out = tmp_path / "quiet.tar.gz"
+    result = _run(["export", str(out), "--no-pretty"])
+    assert result.exit_code == 0, _combined_output(result)
+    # Without --no-pretty we'd see "Tables" header; with --no-pretty we don't.
+    assert "Tables" not in result.output
+    # But the final wrote-line is still emitted.
+    assert "manifest_sha256=" in result.output

--- a/tests/portability/test_export_import_roundtrip.py
+++ b/tests/portability/test_export_import_roundtrip.py
@@ -1,0 +1,335 @@
+"""Round-trip test for the OSS portability exporter ↔ importer pair.
+
+The :func:`attestix.portability.bundle_writer.write_bundle` writer is the
+inverse of :class:`attestix.portability.importer.Importer`. These tests:
+
+* Seed a fresh tmp-redirected OSS instance with identities + a credential +
+  several audit events + a compliance profile + an anchor row.
+* Export the seeded state to a tarball on disk.
+* Run the existing :class:`Importer` against the produced bundle on a fresh
+  empty OSS instance (driven via the ``tmp_attestix`` fixture which already
+  redirects storage paths per-test).
+* Assert that row counts, audit-chain re-verification, and manifest sha all
+  round-trip cleanly.
+* Cover the empty-store, ``--workspace`` filter, and ``--no-include-anchors``
+  paths.
+
+The round-trip is the strongest guarantee the constitution makes for OSS
+portability: a bundle produced by OSS must be importable by OSS, and the
+imported state must re-export to a verifiable bundle whose sha matches a
+fresh recomputation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from attestix.audit.events import verify_chain
+from attestix.audit import AuditEventEmitter
+from attestix.auth.crypto import canonicalize_json
+from attestix.portability import (
+    Bundle,
+    Importer,
+    read_bundle,
+    write_bundle,
+)
+from attestix.portability.bundle_writer import EXPORT_PLAN
+from attestix.services.credential_service import CredentialService
+from attestix.services.identity_service import IdentityService
+from attestix.services.compliance_service import ComplianceService
+from attestix.storage import FileRepository
+from attestix.storage.repository import DEFAULT_TENANT
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_oss_data(*, tenant: str = DEFAULT_TENANT) -> dict:
+    """Populate a fresh OSS instance with a representative mix of rows.
+
+    Returns a dict describing what was seeded so assertions can re-verify.
+    """
+    identity_svc = IdentityService(tenant_id=tenant)
+    cred_svc = CredentialService(tenant_id=tenant)
+    compliance_svc = ComplianceService(tenant_id=tenant)
+
+    a1 = identity_svc.create_identity(
+        display_name="Alpha Agent",
+        source_protocol="manual",
+        description="Round-trip seed agent 1",
+    )
+    a2 = identity_svc.create_identity(
+        display_name="Beta Agent",
+        source_protocol="manual",
+        description="Round-trip seed agent 2",
+    )
+
+    cred = cred_svc.issue_credential(
+        agent_id=a1["agent_id"],
+        credential_type="AgentIdentityCredential",
+        issuer_name="VibeTensor Fixture",
+        claims={"role": "round-trip"},
+    )
+
+    profile = compliance_svc.create_compliance_profile(
+        agent_id=a1["agent_id"],
+        risk_category="limited",
+        provider_name="Round-Trip Provider",
+        intended_purpose="Test the OSS exporter ↔ importer pair",
+    )
+
+    # Seed an anchor row directly through the FileRepository — the blockchain
+    # service is network-dependent and we want a hermetic test.
+    repo = FileRepository()
+    repo.create(
+        "anchors",
+        {
+            "anchor_id": "anchor:roundtrip000001",
+            "artifact_type": "identity",
+            "artifact_id": a1["agent_id"],
+            "artifact_hash": "ab" * 32,
+            "network": "sepolia",
+            "chain_id": 84532,
+            "tx_hash": "0x" + "cd" * 32,
+            "attestation_uid": "0x" + "ef" * 32,
+            "schema_uid": "0x" + "12" * 32,
+            "attester": "0x" + "34" * 20,
+            "block_number": 1,
+            "gas_used": 100000,
+            "explorer_url": "https://sepolia.basescan.org/tx/0xcd",
+            "anchored_at": "2026-05-28T12:00:00Z",
+            "issuer_did": "did:key:fixture",
+        },
+        tenant_id=tenant,
+        id_field="anchor_id",
+    )
+
+    # Audit events: the service-layer emits some during create above. We add
+    # one more via the public emitter API so the chain is non-trivial.
+    emitter = AuditEventEmitter()
+    emitter.emit(
+        action="identity.audit_roundtrip",
+        target_id=a1["agent_id"],
+        target_collection="identities",
+        actor="user:roundtrip@test",
+        tenant_id=tenant,
+        after={"agent_id": a1["agent_id"]},
+    )
+
+    return {
+        "tenant": tenant,
+        "agent_ids": [a1["agent_id"], a2["agent_id"]],
+        "credential_id": cred["id"],
+        "profile_id": profile["profile_id"],
+        "anchor_id": "anchor:roundtrip000001",
+    }
+
+
+def _count_audit_rows(tenant: str = DEFAULT_TENANT) -> int:
+    repo = FileRepository()
+    return len(repo.list("audit", tenant_id=tenant, id_field="event_id"))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_empty_store_export_produces_valid_zero_row_bundle(tmp_path):
+    out = tmp_path / "empty.tar.gz"
+    result = write_bundle(out)
+    assert out.exists()
+    assert result.bytes > 0
+
+    bundle = read_bundle(out)
+    ok, problems = bundle.verify()
+    assert ok, problems
+
+    # Every table in the EXPORT_PLAN appears in the bundle (even if zero rows).
+    for spec in EXPORT_PLAN:
+        assert spec.name in bundle.tables
+        assert bundle.tables[spec.name].row_count == 0
+        assert bundle.tables[spec.name].bytes == 0
+
+    # Manifest carries the OSS exporter signature.
+    assert bundle.manifest["exported_by"]["user_id"] == "local"
+    assert bundle.workspace.get("region") == "local"
+    assert bundle.workspace.get("data_residency") == "self-host"
+    assert bundle.db_migration_max == "0010"
+
+
+def test_seeded_export_round_trips_through_importer(tmp_path):
+    """Export seeded OSS state, re-import it on a *fresh* OSS instance, assert equivalence.
+
+    The ``tmp_attestix`` autouse fixture redirects storage paths per-test —
+    inside this test we first seed, then export to a tmp file, then *reset*
+    the FileRepository state by clearing the documents (the fixture's tmp_path
+    persists for the duration of the test), then import and re-verify.
+    """
+    seeded = _seed_oss_data()
+    audit_count_pre = _count_audit_rows()
+
+    out = tmp_path / "seeded.tar.gz"
+    result = write_bundle(out)
+
+    # The bundle should carry our seeded rows.
+    bundle = read_bundle(out)
+    ok, problems = bundle.verify()
+    assert ok, problems
+
+    assert bundle.tables["identities"].row_count == 2
+    assert bundle.tables["credentials"].row_count == 1
+    assert bundle.tables["compliance_profiles"].row_count == 1
+    assert bundle.tables["anchors"].row_count == 1
+    # Audit count: equal to whatever the OSS emitter+services accumulated.
+    assert bundle.tables["audit_events"].row_count == audit_count_pre
+
+    # Wipe OSS state (re-write empty documents through the same Repository the
+    # importer uses). Then import the bundle and confirm every row reappears.
+    repo = FileRepository()
+    repo.save_document("identities", {"agents": []})
+    repo.save_document("credentials", {"credentials": []})
+    repo.save_document(
+        "compliance",
+        {"profiles": [], "assessments": [], "declarations": []},
+    )
+    repo.save_document("anchors", {"anchors": []})
+    repo.save_document("audit", {"events": []})
+
+    # Re-parse the bundle so the in-memory payload is fresh.
+    bundle = read_bundle(out)
+    importer = Importer(tenant_id=bundle.workspace.get("slug", DEFAULT_TENANT))
+    assert importer.local_data_is_empty()
+    import_result = importer.run(bundle)
+    assert import_result.chain_verified is True
+
+    # Round-trip equivalence.
+    workspace_tenant = bundle.workspace.get("slug")
+    assert (
+        len(repo.list("identities", tenant_id=workspace_tenant, id_field="agent_id"))
+        == 2
+    )
+    assert (
+        len(repo.list("credentials", tenant_id=workspace_tenant, id_field="id"))
+        == 1
+    )
+    assert (
+        len(repo.list("compliance", tenant_id=workspace_tenant, id_field="profile_id"))
+        == 1
+    )
+    assert (
+        len(repo.list("anchors", tenant_id=workspace_tenant, id_field="anchor_id"))
+        == 1
+    )
+
+    # Re-verify the audit chain end-to-end through the OSS helper.
+    audit_rows = repo.list(
+        "audit", tenant_id=workspace_tenant, id_field="event_id"
+    )
+    chain_rows = [
+        {
+            k: v
+            for k, v in r.items()
+            if not k.startswith("_")
+        }
+        for r in audit_rows
+    ]
+    assert verify_chain(chain_rows)
+
+
+def test_deterministic_re_export_is_byte_identical(tmp_path):
+    """Two consecutive exports of identical OSS state must produce identical bytes."""
+    _seed_oss_data()
+
+    out_a = tmp_path / "a.tar.gz"
+    out_b = tmp_path / "b.tar.gz"
+
+    # Pin the exporter clock so the manifest timestamp is identical across runs.
+    from datetime import datetime, timezone
+
+    fixed_now = datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc)
+    result_a = write_bundle(out_a, now=fixed_now)
+    result_b = write_bundle(out_b, now=fixed_now)
+
+    bytes_a = out_a.read_bytes()
+    bytes_b = out_b.read_bytes()
+    assert hashlib.sha256(bytes_a).hexdigest() == hashlib.sha256(bytes_b).hexdigest()
+    assert bytes_a == bytes_b
+    assert result_a.manifest_sha256 == result_b.manifest_sha256
+
+
+def test_workspace_filter_excludes_other_tenants(tmp_path):
+    """Rows tagged with another tenant must not appear in a workspace-scoped export.
+
+    Goes through the Repository directly so the rows carry an explicit
+    ``tenant_id`` tag (the high-level IdentityService writes without one and
+    the FR-013 legacy-fallback would otherwise lump every row under
+    ``"default"``).
+    """
+    repo = FileRepository()
+    for i in range(2):
+        repo.create(
+            "identities",
+            {
+                "agent_id": f"attestix:primary-tenant-{i}",
+                "display_name": f"Primary {i}",
+                "did": f"did:key:primary-{i}",
+                "issuer": {"name": "Fixture", "did": f"did:key:primary-{i}"},
+                "created_at": "2026-05-28T12:00:00Z",
+            },
+            tenant_id="primary",
+            id_field="agent_id",
+        )
+    repo.create(
+        "identities",
+        {
+            "agent_id": "attestix:other-tenant-only",
+            "display_name": "Other",
+            "did": "did:key:other",
+            "issuer": {"name": "Fixture", "did": "did:key:other"},
+            "created_at": "2026-05-28T12:00:00Z",
+        },
+        tenant_id="secondary",
+        id_field="agent_id",
+    )
+
+    out = tmp_path / "primary-only.tar.gz"
+    write_bundle(out, workspace="primary")
+    bundle = read_bundle(out)
+
+    # 2 identities in `primary`; the `secondary` row must be filtered out.
+    assert bundle.tables["identities"].row_count == 2
+    seen = [row["core_object_ref"] for row in bundle.iter_rows("identities")]
+    assert "attestix:other-tenant-only" not in seen
+    # And the workspace identity in the manifest is the chosen tenant.
+    assert bundle.workspace.get("slug") == "primary"
+
+
+def test_no_include_anchors_emits_zero_anchor_rows(tmp_path):
+    _seed_oss_data()
+    out = tmp_path / "no-anchors.tar.gz"
+    write_bundle(out, include_anchors=False)
+    bundle = read_bundle(out)
+    # The table is still in the manifest (cloud parity); the row count is 0.
+    assert "anchors" in bundle.tables
+    assert bundle.tables["anchors"].row_count == 0
+    assert bundle.tables["anchors"].bytes == 0
+
+
+def test_manifest_sha_matches_fresh_recomputation(tmp_path):
+    _seed_oss_data()
+    out = tmp_path / "manifest-sha.tar.gz"
+    result = write_bundle(out)
+
+    bundle = read_bundle(out)
+    # The reader recomputes via the same canonicaliser.
+    assert bundle.verify_manifest()
+    # And the recomputed sha matches the result's reported sha.
+    assert (
+        hashlib.sha256(canonicalize_json(bundle.manifest)).hexdigest()
+        == result.manifest_sha256
+    )


### PR DESCRIPTION
## What
**OSS `attestix export <output.tar.gz>`** — the symmetric counterpart to `attestix import` (PR #93) and the cloud M6 P1 worker. **Closes the constitutional "portability is a right" principle** end-to-end: OSS → cloud and cloud → OSS, byte-interchangeable bundles.

This is the persona-review's **#1 critical fix** — the Bedrock cross-family adversary (GLM-5) caught that the previous tier matrix accidentally gave OSS users import-only portability, violating the zero-lock-in promise.

### CLI
```
attestix export <output.tar.gz> [--workspace <name>] [--no-include-anchors] [--force]
```
- One progress line per table: `[✓] audit_events  N rows  sha256:abc12345…`.
- Final line: `wrote <path>  <bytes>  manifest_sha256=<…>`.
- Refuses to overwrite without `--force`.

### Wire-format parity (https://attestix.io/spec/bundle/v1)
Mirrors the cloud worker `apps/workers/ts/src/exports.ts` **field-for-field** so cloud↔OSS bundles are byte-interchangeable. Member order matches the cloud's `EXPORT_TABLE_SPECS`. USTAR `mtime=0` + gzip header `mtime=0` + alphabetical member order → **byte-identical re-exports** (verified by `test_deterministic_re_export_is_byte_identical`).

### EXPORT_PLAN (in `attestix/portability/bundle_writer.py`)
| bundle table | OSS collection | OSS→cloud projector |
|---|---|---|
| `identities` | `identities.agents` | `_row_identity_to_cloud` |
| `credentials` | `credentials.credentials` | `_row_credential_to_cloud` |
| `compliance_profiles` | `compliance.profiles` | `_row_compliance_profile_to_cloud` |
| `conformity_assessments` | `compliance.assessments` | `_row_conformity_assessment_to_cloud` |
| `audit_events` | `audit.events` | `_row_audit_event_to_cloud` |
| `anchors` | `anchors.anchors` | `_row_anchor_to_cloud` |

Cloud-only tables (key_references, credential_schemas, memberships, team_invites, subscriptions, agent_dependencies, webhook_endpoints) are emitted as empty JSONL so the manifest count stays cloud-symmetric.

### Audit chain integrity
The exporter inspects `audit.events` and uses each event's `tenant_id` as the bundle's `workspace.slug`. If multiple tenants exist without `--workspace` filter, errors. This guarantees the importer's `_project_audit_event` re-tags rows with the same tenant the chain was originally hashed under — so `verify_chain` round-trips cleanly.

### Round-trip metadata preservation
Rows that carry `_cloud_id` / `_cloud_workspace_id` (stamped by a prior import) reuse those values rather than synthesising new ones — so a cloud → OSS → export cycle preserves the same cloud UUIDs. OSS-only rows that never round-tripped get **UUID5 over `(table, row_id)` via a frozen namespace** for stable hashes.

### No second canonicaliser
Reuses `attestix.auth.crypto.canonicalize_json` everywhere (manifest sha-256, JSONL row sha-256, audit-chain integrity check).

## Test plan
- **519 tests pass** (507 → 519, +12 new). 2 skipped unchanged. Full suite 35–38 s.
- New tests:
  - `tests/portability/test_export_import_roundtrip.py` (6) — seed → export → import → row-count and chain-integrity match; empty store; partial workspace export; `--no-include-anchors`; deterministic byte-identical re-export.
  - `tests/cli/test_export_command.py` (6) — CLI writes file + exit 0; refuses on existing target; `--force` proceeds; round-trip through `attestix import --verify-only`.
- Bundle size from a representative seeded store (5 agents + 5 credentials + 5 compliance profiles + 20 audit events): **6,654 bytes total** (5.4KB credentials + 4.6KB compliance + 14KB audit, gzip ~3–5x).

## Deferred to next slice
- `.tar.zst` output (cloud worker is also `.tar.gz` only today — P2 parity).
- Streaming export for very large stores (current matches importer's 256 MiB cap).
- `website/content/docs/portability/export.mdx` doc page.
