### PR TITLE
fix(cli,docs): bundle e2e walkthrough P0/P1s — Windows UTF-8 + status audit count + mlops mdx

### DIFF
--- a/attestix/cli.py
+++ b/attestix/cli.py
@@ -12,7 +12,22 @@ from pathlib import Path
 
 import click
 
-from attestix.config import DATA_DIR, load_identities, load_credentials, load_compliance, load_provenance
+# Windows: ensure UTF-8 stdout/stderr so progress glyphs (->, arrows, etc.)
+# and any unicode in CLI output don't crash under cp1252 (Git Bash inherits
+# the legacy console encoding).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+from attestix.config import (
+    AUDIT_FILE,
+    DATA_DIR,
+    load_compliance,
+    load_credentials,
+    load_identities,
+    load_provenance,
+)
 from attestix.services.cache import get_service
 from attestix.services.identity_service import IdentityService
 from attestix.services.compliance_service import ComplianceService
@@ -425,7 +440,18 @@ def status():
 
     provenance_data = load_provenance()
     prov_entries = provenance_data.get("entries", [])
-    audit_entries = provenance_data.get("audit_log", [])
+
+    # Audit chain (v0.4.0+) is persisted in audit.json with schema
+    # {"events": [...]}. Previously this read provenance.json["audit_log"],
+    # which silently reported 0 after every `attestix import` because the
+    # importer writes to audit.json.
+    audit_data: dict = {}
+    if AUDIT_FILE.exists():
+        try:
+            audit_data = json.loads(AUDIT_FILE.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            audit_data = {}
+    audit_entries = audit_data.get("events", [])
 
     _header("Resource Counts")
     click.echo(f"  Agents (active)    : {len(active_agents)}")

--- a/website/content/docs/quickstart/mlops-engineer.mdx
+++ b/website/content/docs/quickstart/mlops-engineer.mdx
@@ -44,7 +44,8 @@ A GitHub Actions step that, on every model promotion, registers the model lineag
             capabilities=[os.environ["MODEL_TASK"]],
             issuer_name="VibeTensor",
         )["agent_id"]
-        print(f"::set-output name=agent_id::{agent_id}")
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+            f.write(f"agent_id={agent_id}\n")
 
     ProvenanceService().record_model_lineage(
         agent_id=agent_id,
@@ -88,7 +89,8 @@ attestix audit "$AGENT_ID" --limit 5  # prints the latest hash-chained rows
 If you don't want to share the `.signing_key.json` between runners, run Attestix as a service and call it over HTTP. The REST surface honours `Idempotency-Key` so retried CI runs don't duplicate identities:
 
 ```bash
-attestix mcp --transport http --port 8501 &
+# Start the FastAPI REST surface (the MCP stdio server is `python -m attestix.main`).
+uvicorn attestix.api.main:app --host 127.0.0.1 --port 8501 &
 curl -sX POST http://localhost:8501/identities \
   -H "Idempotency-Key: gha-${GITHUB_RUN_ID}-promote" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## What
Three fixes caught by the internal end-to-end walkthrough (`paper/internal/e2e-flow-verification-2026-05-28.md`, gitignored). Two **P0**, one **P1**. Fourth P1 (`verify_chain` structured return) deferred to its own PR.

### Fix 1 — P0: `attestix export` UnicodeEncodeError on Windows (Git Bash, cp1252)
Every Windows user crashed on first run: `UnicodeEncodeError: 'charmap' codec can't encode character '->' in position N`. Now `sys.stdout.reconfigure(encoding="utf-8", errors="replace")` is called at CLI import time, guarded by `hasattr(sys.stdout, "reconfigure")` for Python <3.7. Fixes the export progress glyphs **and** future unicode in any CLI command — single seam, no per-call escaping.

### Fix 2 — P0/P1: `attestix status` reported 0 audit entries after a successful `attestix import`
Root cause: status was reading `audit_log` from `provenance.json` (legacy v0.3 location), but the v0.4.0+ audit chain is persisted to `audit.json` with schema `{"events": [...]}` — which is also what the new `attestix import` writes to. Now reads `AUDIT_FILE` directly with `json.JSONDecodeError` + `OSError` guards.

### Fix 3 — P1: `website/content/docs/quickstart/mlops-engineer.mdx`
- Replace deprecated `print("::set-output name=…")` with the `$GITHUB_OUTPUT` append pattern (GHA deprecated `set-output` in 2022, broken since 2023 default).
- Replace the non-existent `attestix mcp --transport http --port 8501` subcommand with `uvicorn attestix.api.main:app --host 127.0.0.1 --port 8501` for the REST surface. (The MCP stdio server is `python -m attestix.main`; the FastAPI REST surface — which the curl example actually hits — needs uvicorn.)

## Test plan
- `pytest -q` → **519 passed, 2 skipped, 0 failed** (unchanged from main).
- Manual: `attestix export local.tar.gz` on Windows Git Bash with `PYTHONIOENCODING=ascii` (simulating cp1252) — no longer crashes.
- Manual: `attestix import sample.tar.gz` then `attestix status` — now correctly reports the imported audit event count.

## Deferred to follow-up
P1 #4 from the walkthrough — `verify_chain` returns only `bool` with no broken-event pointer. Wants a `VerifyChainResult` dataclass with `broken_event_id` + `broken_field` + `failure_reason` + `events_checked`, plus back-compat `__bool__`. Larger refactor + tests — separate PR.

Also from the walkthrough:
- `@vibetensor/attestix@0.2.0` not yet on npm (presentation persona-review also flagged this).
- `attestix status` env var brief said `ATTESTIX_HOME` — actual var is `ATTESTIX_DATA_DIR`. Internal-tooling-only correction.
