### PR TITLE
docs: rename @vibetensor/attestix -> attestix across public-facing docs + migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ streamlit run demo/webapp/app.py         # Opens at http://localhost:8501
 python examples/quickstart.py            # Full 9-module workflow in 0.1 seconds
 ```
 
+### JS / TS verifier
+
+Verify Attestix-issued credentials offline from JavaScript or TypeScript:
+
+```bash
+npm install attestix
+```
+
+Source: <https://github.com/VibeTensor/attestix-js> · npm: <https://www.npmjs.com/package/attestix>
+
+Same canonical-JSON form (RFC 8785) and Ed25519 verification (RFC 8032) as
+the Python core. ~68 KB packaged, one runtime dependency
+(`@noble/curves`). The pre-rename scoped name `@vibetensor/attestix` is
+deprecated — see the
+[npm rename migration guide](https://attestix.io/docs/guides/migration-npm-rename)
+if you are upgrading.
+
 ## Why Attestix
 
 On **August 2, 2026**, the EU AI Act enforcement begins. Fines reach EUR 35M or 7% of global revenue.

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -11,6 +11,7 @@
     "crewai",
     "offline-verify",
     "base-l2-anchor",
-    "migration-v0.4.0-namespace"
+    "migration-v0.4.0-namespace",
+    "migration-npm-rename"
   ]
 }

--- a/website/content/docs/guides/migration-npm-rename.mdx
+++ b/website/content/docs/guides/migration-npm-rename.mdx
@@ -1,0 +1,122 @@
+---
+title: npm package rename — @vibetensor/attestix → attestix
+description: How to migrate to the bare 'attestix' name on npm (now matching pip install attestix on PyPI).
+---
+
+# npm package rename — `@vibetensor/attestix` → `attestix`
+
+**TL;DR** — the JS/TS verifier package is now published as bare `attestix`
+on npm, matching `pip install attestix` on PyPI. The old scoped name
+`@vibetensor/attestix` is **deprecated** and will receive no new versions.
+
+## What changed
+
+| | Before | After |
+|---|---|---|
+| **npm name** | `@vibetensor/attestix` | `attestix` |
+| **Install command** | `npm install @vibetensor/attestix` | `npm install attestix` |
+| **Import** | `from '@vibetensor/attestix'` | `from 'attestix'` |
+| **PyPI name** | `attestix` | `attestix` (unchanged) |
+
+The intent is symmetry — `pip install attestix` and `npm install attestix`
+install the language-respective verifier under one canonical name.
+
+## Migration in 60 seconds
+
+```bash
+# 1. Uninstall the scoped package:
+npm uninstall @vibetensor/attestix
+
+# 2. Install the bare package:
+npm install attestix
+
+# 3. Find and replace imports across your repo
+#    (POSIX / Git Bash / WSL — adjust for your shell):
+grep -rln "@vibetensor/attestix" . --include='*.{js,ts,jsx,tsx,mjs,cjs}' \
+  | xargs sed -i 's|@vibetensor/attestix|attestix|g'
+```
+
+The exports and API surface are **identical** — only the package name
+changed. No source code changes are required beyond the import string.
+
+### Before / after
+
+```ts
+// Before
+import { verifyCredential } from '@vibetensor/attestix'
+
+// After
+import { verifyCredential } from 'attestix'
+```
+
+```json
+// package.json — before
+{
+  "dependencies": {
+    "@vibetensor/attestix": "^0.2.0"
+  }
+}
+
+// package.json — after
+{
+  "dependencies": {
+    "attestix": "^0.2.0"
+  }
+}
+```
+
+## Why we renamed
+
+- **Symmetry with PyPI.** `pip install attestix` was always the canonical
+  Python install. The scoped npm name created asymmetric muscle memory.
+- **Cleaner install command** for blog posts, tutorials, and quickstarts.
+- **Cross-language ecosystem coherence** — future Rust crate (`attestix`),
+  Go module (`github.com/VibeTensor/attestix-go`), and other ports follow
+  the same bare-name pattern.
+
+## Deprecation timeline
+
+| Date | Event |
+|------|-------|
+| 2026-05-28 | `attestix@0.2.0` published to npm. `@vibetensor/attestix@0.2.0` deprecated with a redirect message in the `npm install` output. |
+| 2026-06-30 | Last scoped patch (`@vibetensor/attestix@0.2.1`) ships only if a P0 security fix is required. |
+| 2026-08-01 | Scoped name receives no further updates. Use `npm install attestix` for all new versions. |
+
+The scoped package will remain installable indefinitely (npm does not
+unpublish packages older than 72 hours after first publish) — but it
+freezes at the deprecation date.
+
+## Verify your migration
+
+After replacing the import string, confirm the bare package resolves:
+
+```bash
+node -e "console.log(require('attestix'))"
+```
+
+You should see the exported surface. If you still get
+`Cannot find module 'attestix'`, the install step did not run — re-run
+`npm install attestix` from the project root.
+
+For TypeScript projects, make sure `tsc --noEmit` still passes after the
+rename:
+
+```bash
+npx tsc --noEmit
+```
+
+The type declarations are identical between the two package names.
+
+## Where the source lives
+
+- **Python core + Annex IV / VC issuance:** https://github.com/VibeTensor/attestix
+- **JS/TS verifier (this package):** https://github.com/VibeTensor/attestix-js
+- **Cloud (private):** https://attestix.io
+
+## See also
+
+- [Offline Verification Walkthrough](/docs/guides/offline-verify) — the
+  same canonical-JSON form + Ed25519 verification, in Python.
+- [Migrating to the canonical `attestix.*` namespace
+  (v0.4.0-rc.2)](/docs/guides/migration-v0.4.0-namespace) — the
+  Python-side namespace migration for the same release.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -41,6 +41,7 @@ Attestix provides verifiable identity, W3C credentials, delegation chains, compl
 - [Risk Classification](https://attestix.io/docs/guides/risk-classification): Decision tree for AI Act risk categories
 - [Integration Guide](https://attestix.io/docs/guides/integration-guide): LangChain, OpenAI Agents SDK, CrewAI, plain Python
 - [Reputation Scoring](https://attestix.io/docs/guides/reputation): Trust scoring, categories, recency decay
+- [npm rename migration](https://attestix.io/docs/guides/migration-npm-rename): @vibetensor/attestix → attestix (bare name on npm, matches pip install attestix)
 - [API Reference](https://attestix.io/docs/reference/api-reference): All 47 tools with parameters and return types
 - [Concepts](https://attestix.io/docs/reference/concepts): UAIT, DID, VC, VP, UCAN, Ed25519 explained
 - [Configuration](https://attestix.io/docs/reference/configuration): Environment variables and setup
@@ -96,6 +97,14 @@ Attestix provides verifiable identity, W3C credentials, delegation chains, compl
 ```
 pip install attestix
 ```
+
+JS/TS verifier (same canonical-JSON form + Ed25519 verification):
+
+```
+npm install attestix
+```
+
+The scoped npm name `@vibetensor/attestix` is deprecated as of 2026-05-28; use the bare `attestix` package. See https://attestix.io/docs/guides/migration-npm-rename for the migration guide.
 
 ## Links
 


### PR DESCRIPTION
## Summary

The JS/TS verifier is being republished on npm under the bare name `attestix`, matching `pip install attestix` on PyPI. This PR brings the public-facing docs in line and adds a Fumadocs migration page for anyone still on the scoped name `@vibetensor/attestix`.

- **New migration guide** at `website/content/docs/guides/migration-npm-rename.mdx` — covers the rename, a 60-second migration recipe (`npm uninstall @vibetensor/attestix && npm install attestix`), the deprecation timeline (publish 2026-05-28, last security patch 2026-06-30, freeze 2026-08-01), and a TS / `package.json` before-after.
- **Registered in Fumadocs nav** via `website/content/docs/guides/meta.json` so it sits next to the existing `migration-v0.4.0-namespace` page.
- **README**: added a "JS / TS verifier" section near the install instructions pointing at `npm install attestix`, the source repo (`VibeTensor/attestix-js`), and the new migration guide. Notes the `@noble/curves` dep and the canonical-JSON + Ed25519 conformance with the Python core.
- **`llms.txt`**: added the new migration page to the Docs index and an `npm install attestix` snippet in the Install section so the AI-discoverable docs cover both package managers under the same name.

## Notes for reviewers

- **The sweep was a no-op for pre-existing content.** A `grep -rn '@vibetensor/attestix'` against `README.md`, `website/`, and `paper/outreach.txt` returned **zero hits before this PR** — the scoped name was not yet referenced anywhere in the OSS repo. The only `@vibetensor/attestix` occurrences that now exist are the legitimate deprecation notices in the new migration page, the README's "JS / TS verifier" section, and the `llms.txt` install snippet.
- **Python sources untouched.** `attestix/`, `tests/`, and `pyproject.toml` do not reference the npm name and were intentionally left alone. The Cloud monorepo is a separate repo and out of scope.
- **VibeTensor branding preserved.** No Acme / TUV Sud / etc.
- **Base L2 testnet language preserved** in the surrounding copy (Sepolia only).

## Build status

- `npx next build` completes clean: **74 routes generated** (38 docs pages including the new `migration-npm-rename`).
- `npx tsc --noEmit` exits 0.
- New page exports to `out/docs/guides/migration-npm-rename.html` as expected.

## Test plan

- [ ] CI build passes
- [ ] Reviewer visits `/docs/guides/migration-npm-rename` after the website redeploy and confirms it renders, links resolve, and the page appears under the Guides section in the sidebar
- [ ] Reviewer confirms README "JS / TS verifier" section reads cleanly next to the existing install snippets
- [ ] Reviewer confirms `llms.txt` install block lists both `pip install attestix` and `npm install attestix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive migration guide with detailed step-by-step instructions, code examples, and deprecation timeline for the npm package namespace update
  * Introduced offline credential verification and validation capability for JavaScript/TypeScript environments with complete setup guidance
  * Updated installation and product documentation with migration resources and support for transitioning users

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VibeTensor/attestix/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->