### PR TITLE
fix(readme): replace 'Acme Corp' placeholder with VibeTensor in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ agent = identity_svc.create_identity(
     source_protocol="manual",
     capabilities=["data_analysis", "reporting"],
     description="Analyzes quarterly financial data",
-    issuer_name="Acme Corp",
+    issuer_name="VibeTensor",
     expiry_days=365,
 )
 agent_id = agent["agent_id"]      # attestix:f9bdb7a94ccb40f1
@@ -179,7 +179,7 @@ agent_did = agent["issuer"]["did"]  # did:key:z6Mk...
 profile = compliance_svc.create_compliance_profile(
     agent_id=agent_id,
     risk_category="limited",
-    provider_name="Acme Corp",
+    provider_name="VibeTensor",
     intended_purpose="Analyzes quarterly financial data",
 )
 
@@ -187,7 +187,7 @@ profile = compliance_svc.create_compliance_profile(
 credential = credential_svc.issue_credential(
     subject_id=agent_id,
     credential_type="AgentIdentityCredential",
-    issuer_name="Acme Corp",
+    issuer_name="VibeTensor",
     claims={"capabilities": ["data_analysis", "reporting"]},
     expiry_days=365,
 )


### PR DESCRIPTION
Project memory hygiene rule says all example issuer/provider names use VibeTensor (not Acme/TUV Sud/etc). The OSS README code example still used 'Acme Corp' from a much earlier draft — 3 occurrences across the issuer_name + provider_name fields in the quickstart Python snippet. Flagged during PR #102's rename agent.