### PR TITLE
feat(cli,services): --json CLI flag (#36) + list filters & bulk report (#37) + record_* param aliases (#39)

### DIFF
--- a/attestix/cli.py
+++ b/attestix/cli.py
@@ -129,7 +129,8 @@ def init(name, protocol, description, capabilities, identity_token, issuer, expi
 
 @cli.command()
 @click.argument("agent_id")
-def verify(agent_id):
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON (CI/CD). Exits 1 if invalid.")
+def verify(agent_id, as_json):
     """Verify an agent identity by its ID.
 
     Checks existence, revocation status, expiry, and cryptographic signature.
@@ -138,6 +139,12 @@ def verify(agent_id):
     result = svc.verify_identity(agent_id)
 
     valid = result.get("valid", False)
+
+    if as_json:
+        _print_json(result)
+        if not valid:
+            sys.exit(1)
+        return
 
     if valid:
         _success(f"Identity {agent_id} is VALID")
@@ -166,7 +173,8 @@ def verify(agent_id):
 @click.option("--risk-category", type=click.Choice(["minimal", "limited", "high"], case_sensitive=False), help="EU AI Act risk category (for --create).")
 @click.option("--provider-name", default="", help="Provider name (for --create).")
 @click.option("--intended-purpose", default="", help="Intended purpose (for --create).")
-def compliance(agent_id, create_profile, risk_category, provider_name, intended_purpose):
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON (CI/CD). Exits non-zero if not compliant.")
+def compliance(agent_id, create_profile, risk_category, provider_name, intended_purpose, as_json):
     """Show compliance status for an agent, or create a new compliance profile.
 
     Without --create, displays a gap analysis of EU AI Act obligations.
@@ -192,14 +200,27 @@ def compliance(agent_id, create_profile, risk_category, provider_name, intended_
             intended_purpose=intended_purpose,
         )
         if "error" in result:
+            if as_json:
+                _print_json(result)
+                sys.exit(1)
             _error(result["error"])
 
+        if as_json:
+            _print_json(result)
+            return
         _success(f"Compliance profile created: {result['profile_id']}")
         _print_json(result)
         return
 
     # Default: show compliance status (gap analysis)
     result = svc.get_compliance_status(agent_id)
+
+    if as_json:
+        _print_json(result)
+        # CI/CD gate: non-zero exit on error OR when the agent is not compliant.
+        if "error" in result or not result.get("compliant"):
+            sys.exit(1)
+        return
 
     if "error" in result:
         _error(result["error"])
@@ -318,7 +339,8 @@ def audit(agent_id, action_type, limit):
 @click.option("--type", "credential_type", default="AgentIdentityCredential", show_default=True, help="Credential type (for --issue).")
 @click.option("--issuer", default="", help="Issuer name (for --issue).")
 @click.option("--claims", default="{}", help="JSON string of claims (for --issue).")
-def credential(do_issue, cred_id_to_verify, do_list, cred_id_to_revoke, agent_id, credential_type, issuer, claims):
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON (CI/CD). --verify-cred exits 1 if invalid.")
+def credential(do_issue, cred_id_to_verify, do_list, cred_id_to_revoke, agent_id, credential_type, issuer, claims, as_json):
     """Issue, verify, list, or revoke W3C Verifiable Credentials.
 
     Examples:
@@ -350,6 +372,11 @@ def credential(do_issue, cred_id_to_verify, do_list, cred_id_to_revoke, agent_id
             issuer_name=issuer,
             claims=parsed_claims,
         )
+        if as_json:
+            _print_json(result)
+            if "error" in result:
+                sys.exit(1)
+            return
         if "error" in result:
             _error(result["error"])
 
@@ -358,8 +385,16 @@ def credential(do_issue, cred_id_to_verify, do_list, cred_id_to_revoke, agent_id
 
     elif cred_id_to_verify:
         result = svc.verify_credential(cred_id_to_verify)
+        valid = result.get("valid", False)
 
-        if result.get("valid"):
+        if as_json:
+            _print_json(result)
+            # Preserve verify-style CI semantics: exit 1 when invalid.
+            if not valid:
+                sys.exit(1)
+            return
+
+        if valid:
             _success(f"Credential {cred_id_to_verify} is VALID")
         else:
             _warn(f"Credential {cred_id_to_verify} is INVALID")
@@ -373,6 +408,10 @@ def credential(do_issue, cred_id_to_verify, do_list, cred_id_to_revoke, agent_id
         click.echo()
         _print_json(result)
 
+        # CI/CD gate: exit 1 on invalid credential (parity with `verify`).
+        if not valid:
+            sys.exit(1)
+
     elif do_list:
         if not agent_id:
             agent_id = click.prompt("Agent ID (optional, leave blank to list all)", default="")
@@ -380,7 +419,14 @@ def credential(do_issue, cred_id_to_verify, do_list, cred_id_to_revoke, agent_id
                 agent_id = None
         results = svc.list_credentials(agent_id=agent_id)
         if results and "error" in results[0]:
+            if as_json:
+                _print_json(results[0])
+                sys.exit(1)
             _error(results[0]["error"])
+
+        if as_json:
+            _print_json({"agent_id": agent_id, "count": len(results), "credentials": results})
+            return
 
         if not results:
             _warn(f"No credentials found{' for ' + agent_id if agent_id else ''}.")
@@ -400,8 +446,13 @@ def credential(do_issue, cred_id_to_verify, do_list, cred_id_to_revoke, agent_id
             click.echo()
 
     elif cred_id_to_revoke:
-        reason = click.prompt("Revocation reason (optional)", default="")
+        reason = "" if as_json else click.prompt("Revocation reason (optional)", default="")
         result = svc.revoke_credential(cred_id_to_revoke, reason=reason)
+        if as_json:
+            _print_json(result)
+            if "error" in result:
+                sys.exit(1)
+            return
         if "error" in result:
             _error(result["error"])
         _success(f"Credential revoked: {cred_id_to_revoke}")
@@ -416,7 +467,8 @@ def credential(do_issue, cred_id_to_verify, do_list, cred_id_to_revoke, agent_id
 # ---------------------------------------------------------------------------
 
 @cli.command()
-def status():
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON (CI/CD).")
+def status(as_json):
     """Show system status: data directory, version, and resource counts."""
     # Version
     try:
@@ -428,10 +480,11 @@ def status():
         except ImportError:
             ver = "unknown"
 
-    _header("Attestix System Status")
-    click.echo(f"  Version    : {ver}")
-    click.echo(f"  Data dir   : {DATA_DIR}")
-    click.echo()
+    if not as_json:
+        _header("Attestix System Status")
+        click.echo(f"  Version    : {ver}")
+        click.echo(f"  Data dir   : {DATA_DIR}")
+        click.echo()
 
     # Count resources
     identities = load_identities()
@@ -462,6 +515,21 @@ def status():
             audit_data = {}
     audit_entries = audit_data.get("events", [])
 
+    if as_json:
+        _print_json({
+            "version": ver,
+            "data_dir": str(DATA_DIR),
+            "agents_active": len(active_agents),
+            "agents_revoked": len(revoked_agents),
+            "credentials": len(creds),
+            "credentials_active": len(active_creds),
+            "compliance_profiles": len(profiles),
+            "declarations": len(declarations),
+            "provenance_entries": len(prov_entries),
+            "audit_log_entries": len(audit_entries),
+        })
+        return
+
     _header("Resource Counts")
     click.echo(f"  Agents (active)    : {len(active_agents)}")
     click.echo(f"  Agents (revoked)   : {len(revoked_agents)}")
@@ -480,14 +548,25 @@ def status():
 @click.option("--protocol", default=None, help="Filter by source protocol.")
 @click.option("--include-revoked", is_flag=True, help="Include revoked identities.")
 @click.option("--limit", default=50, type=int, show_default=True, help="Maximum entries to return.")
-def list_identities(protocol, include_revoked, limit):
+@click.option("--risk-category", default=None, type=click.Choice(["minimal", "limited", "high", "unacceptable"], case_sensitive=False), help="Filter by EU AI Act risk category (joins compliance profiles).")
+@click.option("--name-contains", default=None, help="Case-insensitive substring filter on display name.")
+@click.option("--status", "status_filter", default=None, type=click.Choice(["active", "revoked", "expired"], case_sensitive=False), help="Filter by lifecycle status.")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON (CI/CD).")
+def list_identities(protocol, include_revoked, limit, risk_category, name_contains, status_filter, as_json):
     """List all agent identities."""
     svc = get_service(IdentityService)
     agents = svc.list_identities(
         source_protocol=protocol,
         include_revoked=include_revoked,
         limit=limit,
+        risk_category=risk_category,
+        name_contains=name_contains,
+        status=status_filter,
     )
+
+    if as_json:
+        _print_json({"count": len(agents), "agents": agents})
+        return
 
     if not agents:
         _warn("No agent identities found.")

--- a/attestix/services/identity_service.py
+++ b/attestix/services/identity_service.py
@@ -171,15 +171,89 @@ class IdentityService:
         source_protocol: Optional[str] = None,
         include_revoked: bool = False,
         limit: int = 50,
+        risk_category: Optional[str] = None,
+        name_contains: Optional[str] = None,
+        status: Optional[str] = None,
     ) -> List[dict]:
-        """List UAITs with optional filters."""
+        """List UAITs with optional filters.
+
+        All filters compose with logical AND and preserve every existing
+        parameter and default (issue #37).
+
+        Args:
+            source_protocol: Exact-match filter on the identity source protocol.
+            include_revoked: Include revoked identities (default excludes them).
+            limit: Maximum number of identities to return.
+            risk_category: Filter to agents whose EU AI Act compliance profile
+                carries this risk category ("minimal"|"limited"|"high"|
+                "unacceptable"). Joined in the service layer against the
+                compliance profiles keyed by ``agent_id``. Agents without a
+                profile are excluded when this filter is set.
+            name_contains: Case-insensitive substring match on ``display_name``.
+            status: Lifecycle status filter — "active" (not revoked, not
+                expired), "revoked", or "expired". When ``status`` is set it is
+                authoritative; "revoked"/"expired" implicitly include the
+                relevant agents regardless of ``include_revoked``.
+        """
         data = load_identities()
+
+        # Build the agent_id -> risk_category join up-front so each agent is
+        # O(1) to classify (issue #37). Compliance profiles are keyed by
+        # agent_id in ComplianceService storage.
+        risk_by_agent: dict = {}
+        if risk_category is not None:
+            from attestix.config import load_compliance
+            comp_data = load_compliance()
+            for profile in comp_data.get("profiles", []):
+                aid = profile.get("agent_id")
+                if aid:
+                    risk_by_agent[aid] = profile.get("risk_category")
+
+        wanted_risk = risk_category.lower() if risk_category else None
+        wanted_name = name_contains.lower() if name_contains else None
+        wanted_status = status.lower() if status else None
+        now = datetime.now(timezone.utc)
+
         results = []
         for agent in data["agents"]:
-            if not include_revoked and agent.get("revoked"):
-                continue
+            revoked = bool(agent.get("revoked"))
+
+            # Compute lifecycle status (active|revoked|expired) for the agent.
+            expired = False
+            expires_at = agent.get("expires_at")
+            if expires_at and not revoked:
+                try:
+                    expired = now >= datetime.fromisoformat(expires_at)
+                except ValueError:
+                    expired = False
+            if revoked:
+                agent_status = "revoked"
+            elif expired:
+                agent_status = "expired"
+            else:
+                agent_status = "active"
+
+            if wanted_status is not None:
+                # An explicit status filter is authoritative over include_revoked.
+                if agent_status != wanted_status:
+                    continue
+            else:
+                # Legacy behaviour: hide revoked unless include_revoked is set.
+                if not include_revoked and revoked:
+                    continue
+
             if source_protocol and agent.get("source_protocol") != source_protocol:
                 continue
+
+            if wanted_name is not None:
+                if wanted_name not in (agent.get("display_name") or "").lower():
+                    continue
+
+            if wanted_risk is not None:
+                agent_risk = risk_by_agent.get(agent.get("agent_id"))
+                if agent_risk is None or agent_risk.lower() != wanted_risk:
+                    continue
+
             results.append(agent)
             if len(results) >= limit:
                 break

--- a/attestix/services/provenance_service.py
+++ b/attestix/services/provenance_service.py
@@ -70,9 +70,27 @@ class ProvenanceService:
         data_categories: Optional[List[str]] = None,
         contains_personal_data: bool = False,
         data_governance_measures: str = "",
+        dataset_version: str = "",
+        source: str = "",
     ) -> dict:
-        """Record a training data source for an agent (Article 10 compliance)."""
+        """Record a training data source for an agent (Article 10 compliance).
+
+        Args:
+            source_url: Canonical URL of the dataset source. ``source`` is
+                accepted as an alias (issue #39); if both are supplied,
+                ``source_url`` wins.
+            dataset_version: Optional dataset version string (issue #39),
+                stored verbatim in the provenance entry.
+            source: Alias for ``source_url`` (issue #39). Many callers pass
+                ``source=`` intuitively; it is folded into ``source_url``.
+        """
         try:
+            # Issue #39: alias resolution. ``source_url`` is canonical; ``source``
+            # is the common-sense alias researchers reach for. If only ``source``
+            # is given, use it; if both are given, ``source_url`` wins.
+            if not source_url and source:
+                source_url = source
+
             entry_id = f"prov:{uuid.uuid4().hex[:12]}"
             now = datetime.now(timezone.utc).isoformat()
 
@@ -81,6 +99,7 @@ class ProvenanceService:
                 "entry_type": "training_data",
                 "agent_id": agent_id,
                 "dataset_name": dataset_name,
+                "dataset_version": dataset_version,
                 "source_url": source_url,
                 "license": license,
                 "data_categories": data_categories or [],
@@ -123,8 +142,18 @@ class ProvenanceService:
         base_model_provider: str = "",
         fine_tuning_method: str = "",
         evaluation_metrics: Optional[Dict] = None,
+        training_config: Optional[Dict] = None,
     ) -> dict:
-        """Record model lineage chain for an agent (Article 11 compliance)."""
+        """Record model lineage chain for an agent (Article 11 compliance).
+
+        Args:
+            evaluation_metrics: Post-training evaluation metrics (accuracy,
+                F1, etc.), stored verbatim.
+            training_config: Optional training hyper-parameters (epochs, lr,
+                etc.) (issue #39), stored verbatim alongside the metrics.
+                Researchers frequently pass ``training_config=``; it is now
+                an accepted first-class param rather than a TypeError.
+        """
         try:
             entry_id = f"prov:{uuid.uuid4().hex[:12]}"
             now = datetime.now(timezone.utc).isoformat()
@@ -137,6 +166,7 @@ class ProvenanceService:
                 "base_model_provider": base_model_provider,
                 "fine_tuning_method": fine_tuning_method,
                 "evaluation_metrics": evaluation_metrics or {},
+                "training_config": training_config or {},
                 "recorded_at": now,
                 "recorded_by": self._server_did,
             }

--- a/attestix/services/report_service.py
+++ b/attestix/services/report_service.py
@@ -278,6 +278,106 @@ class ReportService:
             "errors": errors,
         }
 
+    def generate_org_report(self, agent_ids: Optional[List[str]] = None) -> dict:
+        """Generate an aggregate organisation-wide compliance report (issue #37).
+
+        Reuses the single-agent compliance status shape (the dict returned by
+        :meth:`ComplianceService.get_compliance_status`) and aggregates it
+        across many agents so a CISO can prove org-wide posture in one call.
+
+        Parameters
+        ----------
+        agent_ids : list of str, optional
+            The agents to include. When ``None`` (the default) every agent in
+            local storage is included.
+
+        Returns
+        -------
+        dict
+            ``{"generated_at", "agent_count", "summary", "agents", "errors"}``
+            where ``summary`` aggregates compliant/non-compliant counts, a
+            risk-category breakdown, and the mean completion percentage, and
+            ``agents`` is a list of per-agent records reusing the single-agent
+            report shape (identity + compliance status). ``errors`` maps
+            agent_id to a message for any agent that could not be summarised.
+        """
+        try:
+            if agent_ids is None:
+                agents = self.identity_svc.list_identities(
+                    include_revoked=True, limit=10_000
+                )
+                agent_ids = [a.get("agent_id") for a in agents if a.get("agent_id")]
+
+            generated_at = datetime.now(timezone.utc).isoformat()
+            agent_records: List[dict] = []
+            errors: dict = {}
+
+            compliant_count = 0
+            non_compliant_count = 0
+            no_profile_count = 0
+            risk_breakdown: dict = {}
+            completion_total = 0.0
+            completion_n = 0
+
+            for agent_id in agent_ids:
+                agent = self.identity_svc.get_identity(agent_id)
+                if not agent:
+                    errors[agent_id] = f"Agent {agent_id} not found"
+                    continue
+
+                profile = self.compliance_svc.get_compliance_profile(agent_id)
+                status = (
+                    self.compliance_svc.get_compliance_status(agent_id)
+                    if profile
+                    else None
+                )
+
+                if status and "error" not in status:
+                    if status.get("compliant"):
+                        compliant_count += 1
+                    else:
+                        non_compliant_count += 1
+                    risk = status.get("risk_category", "unknown")
+                    risk_breakdown[risk] = risk_breakdown.get(risk, 0) + 1
+                    completion_total += float(status.get("completion_pct", 0.0))
+                    completion_n += 1
+                else:
+                    no_profile_count += 1
+
+                agent_records.append(
+                    {
+                        "agent_id": agent_id,
+                        "display_name": agent.get("display_name", ""),
+                        "source_protocol": agent.get("source_protocol", ""),
+                        "revoked": bool(agent.get("revoked")),
+                        "has_compliance_profile": profile is not None,
+                        "compliance_status": status,
+                    }
+                )
+
+            avg_completion = (
+                round(completion_total / completion_n, 1) if completion_n else 0.0
+            )
+
+            return {
+                "generated_at": generated_at,
+                "agent_count": len(agent_ids),
+                "summary": {
+                    "compliant": compliant_count,
+                    "non_compliant": non_compliant_count,
+                    "no_compliance_profile": no_profile_count,
+                    "risk_breakdown": risk_breakdown,
+                    "avg_completion_pct": avg_completion,
+                },
+                "agents": agent_records,
+                "errors": errors,
+            }
+        except Exception as e:
+            msg = log_and_format_error(
+                "generate_org_report", e, ErrorCategory.COMPLIANCE,
+            )
+            return {"error": msg}
+
     # -- bulk rendering helpers --------------------------------------------
 
     @staticmethod

--- a/tests/cli/test_json_flag.py
+++ b/tests/cli/test_json_flag.py
@@ -1,0 +1,184 @@
+"""CLI tests for the ``--json`` flag (issue #36).
+
+DevOps / CI use case: every covered command must emit a single parseable
+JSON object on stdout when ``--json`` is passed, and the CI-gate commands
+must set a non-zero exit code on the failure condition:
+
+* ``attestix compliance <id> --json`` exits 0 when compliant, non-zero
+  otherwise (so ``attestix compliance x --json || echo gate-failed`` works).
+* ``attestix verify <id> --json`` exits 1 when the identity is invalid.
+* ``attestix credential --verify-cred <id> --json`` exits 1 when invalid.
+
+All cases drive the real Click commands through :class:`CliRunner` against the
+tmp-redirected storage (``tmp_attestix`` autouse fixture in conftest).
+"""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from attestix.cli import cli
+from attestix.services.cache import get_service
+from attestix.services.compliance_service import ComplianceService
+from attestix.services.credential_service import CredentialService
+from attestix.services.identity_service import IdentityService
+
+
+def _run(args):
+    try:
+        runner = CliRunner(mix_stderr=False)  # Click <8.3
+    except TypeError:
+        runner = CliRunner()
+    return runner.invoke(cli, args, catch_exceptions=False)
+
+
+def _parse(result) -> dict:
+    """Assert stdout is a single parseable JSON object and return it."""
+    payload = json.loads(result.output)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _make_agent(name="JSON Test Agent", protocol="mcp"):
+    svc = get_service(IdentityService)
+    return svc.create_identity(display_name=name, source_protocol=protocol)["agent_id"]
+
+
+# --- status ----------------------------------------------------------------
+
+def test_status_json_is_parseable():
+    result = _run(["status", "--json"])
+    assert result.exit_code == 0
+    payload = _parse(result)
+    assert "version" in payload
+    assert "agents_active" in payload
+
+
+# --- list ------------------------------------------------------------------
+
+def test_list_json_is_parseable():
+    _make_agent()
+    result = _run(["list", "--json"])
+    assert result.exit_code == 0
+    payload = _parse(result)
+    assert payload["count"] == 1
+    assert isinstance(payload["agents"], list)
+
+
+def test_list_json_empty():
+    result = _run(["list", "--json"])
+    assert result.exit_code == 0
+    payload = _parse(result)
+    assert payload["count"] == 0
+    assert payload["agents"] == []
+
+
+# --- verify ----------------------------------------------------------------
+
+def test_verify_json_valid_exit_zero():
+    agent_id = _make_agent()
+    result = _run(["verify", agent_id, "--json"])
+    assert result.exit_code == 0
+    payload = _parse(result)
+    assert payload["valid"] is True
+
+
+def test_verify_json_invalid_exit_one():
+    result = _run(["verify", "attestix:doesnotexist", "--json"])
+    assert result.exit_code == 1
+    payload = _parse(result)
+    assert payload["valid"] is False
+
+
+# --- compliance (CI gate) --------------------------------------------------
+
+def test_compliance_json_non_compliant_exit_nonzero():
+    agent_id = _make_agent()
+    comp = get_service(ComplianceService)
+    comp.create_compliance_profile(
+        agent_id=agent_id, risk_category="high", provider_name="VibeTensor",
+    )
+    result = _run(["compliance", agent_id, "--json"])
+    # Fresh high-risk profile has many missing obligations -> not compliant.
+    assert result.exit_code != 0
+    payload = _parse(result)
+    assert payload["compliant"] is False
+
+
+def test_compliance_json_compliant_exit_zero():
+    agent_id = _make_agent()
+    comp = get_service(ComplianceService)
+    # Minimal-risk profile: drive it all the way to compliant so the CI gate
+    # exit code is 0.
+    comp.create_compliance_profile(
+        agent_id=agent_id,
+        risk_category="minimal",
+        provider_name="VibeTensor",
+        intended_purpose="demo",
+        transparency_obligations="Users are informed this is an AI system.",
+    )
+    comp.record_conformity_assessment(
+        agent_id=agent_id, assessment_type="self",
+        assessor_name="VibeTensor", result="pass",
+    )
+    from attestix.services.provenance_service import ProvenanceService
+    prov = get_service(ProvenanceService)
+    prov.record_training_data(agent_id, "DemoSet")
+    prov.record_model_lineage(agent_id, "demo-model")
+    comp.generate_declaration_of_conformity(agent_id)
+
+    status = comp.get_compliance_status(agent_id)
+    assert status.get("compliant") is True, status  # sanity: fully compliant
+
+    result = _run(["compliance", agent_id, "--json"])
+    payload = _parse(result)
+    assert result.exit_code == 0
+    assert payload["compliant"] is True
+
+
+def test_compliance_json_no_profile_exit_nonzero():
+    agent_id = _make_agent()
+    result = _run(["compliance", agent_id, "--json"])
+    assert result.exit_code != 0
+    payload = _parse(result)
+    assert "error" in payload
+
+
+# --- credential --verify-cred (CI gate) ------------------------------------
+
+def test_credential_verify_json_valid_exit_zero():
+    agent_id = _make_agent()
+    cred = get_service(CredentialService)
+    issued = cred.issue_credential(
+        subject_id=agent_id,
+        credential_type="AgentIdentityCredential",
+        issuer_name="VibeTensor",
+        claims={},
+    )
+    result = _run(["credential", "--verify-cred", issued["id"], "--json"])
+    assert result.exit_code == 0
+    payload = _parse(result)
+    assert payload["valid"] is True
+
+
+def test_credential_verify_json_invalid_exit_one():
+    result = _run(["credential", "--verify-cred", "urn:uuid:nope", "--json"])
+    assert result.exit_code == 1
+    payload = _parse(result)
+    assert payload["valid"] is False
+
+
+def test_credential_list_json_is_parseable():
+    agent_id = _make_agent()
+    cred = get_service(CredentialService)
+    cred.issue_credential(
+        subject_id=agent_id, credential_type="AgentIdentityCredential",
+        issuer_name="VibeTensor", claims={},
+    )
+    result = _run(["credential", "--list", "--agent-id", agent_id, "--json"])
+    assert result.exit_code == 0
+    payload = _parse(result)
+    assert payload["count"] == 1
+    assert isinstance(payload["credentials"], list)

--- a/tests/unit/test_list_filters.py
+++ b/tests/unit/test_list_filters.py
@@ -1,0 +1,145 @@
+"""Tests for IdentityService.list_identities filters (issue #37, part 1).
+
+Covers each new filter (risk_category, name_contains, status) in isolation
+and in composition, plus confirmation that existing params/behaviour are
+preserved.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def populated(identity_service, compliance_service):
+    """Create a small, deterministic population of agents.
+
+    Returns a dict of label -> agent_id.
+    """
+    fraud = identity_service.create_identity(
+        display_name="Fraud Detector", source_protocol="mcp",
+    )["agent_id"]
+    chat = identity_service.create_identity(
+        display_name="Chatbot Assistant", source_protocol="a2a",
+    )["agent_id"]
+    recsys = identity_service.create_identity(
+        display_name="Recommendation Engine", source_protocol="mcp",
+    )["agent_id"]
+
+    # Compliance profiles for the risk_category join.
+    compliance_service.create_compliance_profile(
+        agent_id=fraud, risk_category="high", provider_name="VibeTensor",
+    )
+    compliance_service.create_compliance_profile(
+        agent_id=chat, risk_category="limited", provider_name="VibeTensor",
+    )
+    # recsys intentionally has NO compliance profile.
+
+    return {"fraud": fraud, "chat": chat, "recsys": recsys}
+
+
+class TestRiskCategoryFilter:
+    def test_high_only(self, identity_service, populated):
+        results = identity_service.list_identities(risk_category="high")
+        ids = {a["agent_id"] for a in results}
+        assert ids == {populated["fraud"]}
+
+    def test_limited_only(self, identity_service, populated):
+        results = identity_service.list_identities(risk_category="limited")
+        ids = {a["agent_id"] for a in results}
+        assert ids == {populated["chat"]}
+
+    def test_excludes_agents_without_profile(self, identity_service, populated):
+        results = identity_service.list_identities(risk_category="high")
+        ids = {a["agent_id"] for a in results}
+        assert populated["recsys"] not in ids
+
+    def test_case_insensitive(self, identity_service, populated):
+        results = identity_service.list_identities(risk_category="HIGH")
+        assert len(results) == 1
+
+
+class TestNameContainsFilter:
+    def test_substring(self, identity_service, populated):
+        results = identity_service.list_identities(name_contains="Fraud")
+        ids = {a["agent_id"] for a in results}
+        assert ids == {populated["fraud"]}
+
+    def test_case_insensitive(self, identity_service, populated):
+        results = identity_service.list_identities(name_contains="chatbot")
+        ids = {a["agent_id"] for a in results}
+        assert ids == {populated["chat"]}
+
+    def test_no_match(self, identity_service, populated):
+        results = identity_service.list_identities(name_contains="nonexistent")
+        assert results == []
+
+
+class TestStatusFilter:
+    def test_active(self, identity_service, populated):
+        results = identity_service.list_identities(status="active")
+        assert len(results) == 3
+
+    def test_revoked(self, identity_service, populated):
+        identity_service.revoke_identity(populated["chat"], reason="test")
+        results = identity_service.list_identities(status="revoked")
+        ids = {a["agent_id"] for a in results}
+        assert ids == {populated["chat"]}
+
+    def test_active_excludes_revoked(self, identity_service, populated):
+        identity_service.revoke_identity(populated["chat"], reason="test")
+        results = identity_service.list_identities(status="active")
+        ids = {a["agent_id"] for a in results}
+        assert populated["chat"] not in ids
+        assert len(results) == 2
+
+    def test_expired(self, identity_service):
+        # Create an already-expired identity (expiry 0 days -> expires "now").
+        agent = identity_service.create_identity(
+            display_name="Expired Agent", source_protocol="mcp", expiry_days=0,
+        )
+        results = identity_service.list_identities(status="expired")
+        ids = {a["agent_id"] for a in results}
+        assert agent["agent_id"] in ids
+
+
+class TestFilterComposition:
+    def test_risk_and_name(self, identity_service, populated):
+        # high-risk AND name contains "Fraud" -> the fraud agent.
+        results = identity_service.list_identities(
+            risk_category="high", name_contains="Fraud",
+        )
+        assert len(results) == 1
+        assert results[0]["agent_id"] == populated["fraud"]
+
+    def test_risk_and_name_no_overlap(self, identity_service, populated):
+        # high-risk AND name contains "Chatbot" -> nothing (chat is limited).
+        results = identity_service.list_identities(
+            risk_category="high", name_contains="Chatbot",
+        )
+        assert results == []
+
+    def test_protocol_and_status(self, identity_service, populated):
+        results = identity_service.list_identities(
+            source_protocol="mcp", status="active",
+        )
+        ids = {a["agent_id"] for a in results}
+        assert ids == {populated["fraud"], populated["recsys"]}
+
+
+class TestBackwardCompatibility:
+    def test_default_call_unchanged(self, identity_service, populated):
+        # No new filters -> same as before: all non-revoked agents.
+        results = identity_service.list_identities()
+        assert len(results) == 3
+
+    def test_protocol_filter_unchanged(self, identity_service, populated):
+        results = identity_service.list_identities(source_protocol="mcp")
+        assert len(results) == 2
+
+    def test_limit_unchanged(self, identity_service, populated):
+        results = identity_service.list_identities(limit=1)
+        assert len(results) == 1
+
+    def test_include_revoked_unchanged(self, identity_service, populated):
+        identity_service.revoke_identity(populated["chat"], reason="test")
+        assert len(identity_service.list_identities()) == 2
+        assert len(identity_service.list_identities(include_revoked=True)) == 3

--- a/tests/unit/test_org_report.py
+++ b/tests/unit/test_org_report.py
@@ -1,0 +1,91 @@
+"""Tests for ReportService.generate_org_report (issue #37, part 2).
+
+Covers the all-agents path (agent_ids=None) and the explicit-subset path,
+plus aggregation of the single-agent compliance status into an org summary.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def org(identity_service, compliance_service):
+    """Three agents: one high-risk with a profile, one limited with a
+    profile, one with no compliance profile at all."""
+    a = identity_service.create_identity(
+        display_name="Fraud Detector", source_protocol="mcp",
+    )["agent_id"]
+    b = identity_service.create_identity(
+        display_name="Chatbot", source_protocol="a2a",
+    )["agent_id"]
+    c = identity_service.create_identity(
+        display_name="No Profile Bot", source_protocol="mcp",
+    )["agent_id"]
+
+    compliance_service.create_compliance_profile(
+        agent_id=a, risk_category="high", provider_name="VibeTensor",
+    )
+    compliance_service.create_compliance_profile(
+        agent_id=b, risk_category="limited", provider_name="VibeTensor",
+    )
+    return {"a": a, "b": b, "c": c}
+
+
+class TestAllAgents:
+    def test_includes_every_agent(self, report_service, org):
+        report = report_service.generate_org_report()
+        assert report["agent_count"] == 3
+        ids = {rec["agent_id"] for rec in report["agents"]}
+        assert ids == set(org.values())
+
+    def test_summary_counts(self, report_service, org):
+        report = report_service.generate_org_report()
+        summary = report["summary"]
+        # Two agents have profiles (both non-compliant fresh), one has none.
+        assert summary["no_compliance_profile"] == 1
+        assert summary["compliant"] + summary["non_compliant"] == 2
+
+    def test_risk_breakdown(self, report_service, org):
+        report = report_service.generate_org_report()
+        breakdown = report["summary"]["risk_breakdown"]
+        assert breakdown.get("high") == 1
+        assert breakdown.get("limited") == 1
+
+    def test_empty_org(self, report_service):
+        report = report_service.generate_org_report()
+        assert report["agent_count"] == 0
+        assert report["agents"] == []
+
+
+class TestSubset:
+    def test_explicit_subset(self, report_service, org):
+        report = report_service.generate_org_report(agent_ids=[org["a"]])
+        assert report["agent_count"] == 1
+        assert report["agents"][0]["agent_id"] == org["a"]
+
+    def test_subset_excludes_others(self, report_service, org):
+        report = report_service.generate_org_report(agent_ids=[org["a"], org["b"]])
+        ids = {rec["agent_id"] for rec in report["agents"]}
+        assert ids == {org["a"], org["b"]}
+        assert org["c"] not in ids
+
+    def test_unknown_agent_recorded_as_error(self, report_service, org):
+        report = report_service.generate_org_report(
+            agent_ids=["attestix:doesnotexist"]
+        )
+        assert "attestix:doesnotexist" in report["errors"]
+
+
+class TestShapeReuse:
+    def test_per_agent_record_carries_compliance_status(self, report_service, org):
+        report = report_service.generate_org_report(agent_ids=[org["a"]])
+        rec = report["agents"][0]
+        assert rec["has_compliance_profile"] is True
+        # Reuses the single-agent get_compliance_status shape.
+        assert "compliant" in rec["compliance_status"]
+        assert "completion_pct" in rec["compliance_status"]
+
+    def test_no_profile_agent_has_null_status(self, report_service, org):
+        report = report_service.generate_org_report(agent_ids=[org["c"]])
+        rec = report["agents"][0]
+        assert rec["has_compliance_profile"] is False
+        assert rec["compliance_status"] is None

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -25,6 +25,46 @@ class TestRecordTrainingData:
         )
         assert result["contains_personal_data"] is True
 
+    def test_dataset_version_stored(self, provenance_service):
+        # Issue #39: dataset_version is a first-class param now.
+        result = provenance_service.record_training_data(
+            agent_id="attestix:bot1",
+            dataset_name="SafetyBench",
+            dataset_version="2.0.1",
+        )
+        assert result["dataset_version"] == "2.0.1"
+
+    def test_source_alias_resolves_to_source_url(self, provenance_service):
+        # Issue #39 repro: source= must work without TypeError and land in
+        # the canonical source_url field.
+        result = provenance_service.record_training_data(
+            agent_id="attestix:bot1",
+            dataset_name="SafetyBench",
+            dataset_version="2.0.1",
+            source="https://huggingface.co/datasets/safetybench",
+            license="CC-BY-4.0",
+        )
+        assert "error" not in result
+        assert result["source_url"] == "https://huggingface.co/datasets/safetybench"
+
+    def test_source_url_wins_over_source_alias(self, provenance_service):
+        result = provenance_service.record_training_data(
+            agent_id="attestix:bot1",
+            dataset_name="SafetyBench",
+            source_url="https://canonical.example/ds",
+            source="https://alias.example/ds",
+        )
+        assert result["source_url"] == "https://canonical.example/ds"
+
+    def test_issue_39_repro_does_not_raise(self, provenance_service):
+        # Exact form from issue #39.
+        result = provenance_service.record_training_data(
+            agent_id="attestix:bot1", dataset_name="SafetyBench",
+            dataset_version="2.0.1",
+            source="https://huggingface.co/...", license="CC-BY-4.0",
+        )
+        assert result["entry_type"] == "training_data"
+
 
 class TestRecordModelLineage:
     """Tests for recording model lineage and fine-tuning metadata."""
@@ -40,6 +80,26 @@ class TestRecordModelLineage:
         assert result["entry_type"] == "model_lineage"
         assert result["base_model"] == "gpt-4"
         assert result["evaluation_metrics"]["accuracy"] == 0.95
+
+    def test_training_config_stored(self, provenance_service):
+        # Issue #39 repro: training_config= must work without TypeError and
+        # land in the entry alongside evaluation_metrics.
+        result = provenance_service.record_model_lineage(
+            agent_id="attestix:bot1", base_model="gpt-4",
+            fine_tuning_method="LoRA",
+            training_config={"epochs": 3, "lr": 1e-5},
+        )
+        assert "error" not in result
+        assert result["training_config"] == {"epochs": 3, "lr": 1e-5}
+
+    def test_training_config_and_metrics_coexist(self, provenance_service):
+        result = provenance_service.record_model_lineage(
+            agent_id="attestix:bot1", base_model="gpt-4",
+            evaluation_metrics={"accuracy": 0.9},
+            training_config={"epochs": 5},
+        )
+        assert result["evaluation_metrics"]["accuracy"] == 0.9
+        assert result["training_config"]["epochs"] == 5
 
 
 class TestLogAction:


### PR DESCRIPTION
Batches three developer-experience issues. Additive only — no existing default behaviour or call signature changes.

## Issue #36 — `--json` flag for CI/CD
- [x] `--json` added to `verify`, `compliance`, `credential`, `status`, `list`
- [x] JSON mode emits a single JSON object and suppresses styled/`_header`/`_success` output (reuses `_print_json`)
- [x] `attestix compliance <id> --json` exits non-zero when not compliant (or on error) — CI gate works: `attestix compliance x --json || echo gate-failed`
- [x] `attestix verify <id>` still exits 1 on invalid; `credential --verify-cred` now exits 1 on invalid too (parity)
- [x] Human (no-flag) output unchanged

## Issue #37 — list filters + bulk report
- [x] `IdentityService.list_identities` gains `risk_category` (joined against compliance profiles by `agent_id`), `name_contains` (case-insensitive substring on `display_name`), `status` (`active`/`revoked`/`expired`); filters compose with AND; existing params/behaviour preserved
- [x] Surfaced on `attestix list` (`--risk-category`, `--name-contains`, `--status`)
- [x] `ReportService.generate_org_report(agent_ids=None)` returns an aggregate dict reusing the single-agent compliance-status shape (`None` => all agents)

## Issue #39 — `record_*` parameter ergonomics (backward-compatible)
- [x] `record_training_data`: add `dataset_version`; accept `source=` alias for `source_url=` (`source_url` wins if both given)
- [x] `record_model_lineage`: add `training_config` alongside `evaluation_metrics`
- [x] Docstrings updated to note canonical param + accepted alias

## Tests
- New: `tests/cli/test_json_flag.py`, `tests/unit/test_list_filters.py`, `tests/unit/test_org_report.py`
- Extended: `tests/unit/test_provenance.py`
- Full suite: **574 passed, 3 skipped** (was 530 passed / 3 skipped → +44 tests). No new runtime deps.

Closes #36
Closes #37
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)