### PR TITLE
perf(storage,audit): O(1)-amortized credential issuance path (closes #108)

### DIFF
--- a/attestix/audit/emitter.py
+++ b/attestix/audit/emitter.py
@@ -61,13 +61,22 @@ class AuditEventEmitter:
         Repository scopes ``list`` by tenant, so cross-tenant events never enter
         this chain (each tenant has its own chain, data-model §4).
         """
-        events = self._repo.list(
-            AUDIT_COLLECTION, tenant_id=tenant_id, id_field="event_id"
-        )
-        if not events:
+        # Performance (issue #108): use the backend's ``last_record`` fast-path
+        # when available (the default FileRepository exposes it) so finding the
+        # chain head is O(1)-from-tail instead of copying the entire, ever-growing
+        # event list on every emit. Fall back to a full ``list`` otherwise.
+        last_record = getattr(self._repo, "last_record", None)
+        if callable(last_record):
+            last = last_record(AUDIT_COLLECTION, tenant_id=tenant_id)
+        else:
+            events = self._repo.list(
+                AUDIT_COLLECTION, tenant_id=tenant_id, id_field="event_id"
+            )
+            last = events[-1] if events else None
+        if not last:
             return GENESIS_HASH
         # Events are appended in order; the last persisted is the chain head.
-        return events[-1].get("chain_hash", GENESIS_HASH)
+        return last.get("chain_hash", GENESIS_HASH)
 
     def emit(
         self,

--- a/attestix/config.py
+++ b/attestix/config.py
@@ -175,6 +175,17 @@ def save_credentials(data: dict):
     _repo().save_document("credentials", data)
 
 
+def append_credential(credential: dict) -> dict:
+    """Append one credential to the store without a full load+rewrite.
+
+    Performance shim for the issuance hot path (issue #108): a pure append avoids
+    the O(N) deep copy that ``load_credentials() -> append -> save_credentials()``
+    incurs on every call. The on-disk ``{"credentials": [...]}`` shape is
+    unchanged (the record is written verbatim, no tenant tagging).
+    """
+    return _repo().append_to_document("credentials", credential)
+
+
 # --- Provenance storage ---
 
 def load_provenance() -> dict:

--- a/attestix/services/credential_service.py
+++ b/attestix/services/credential_service.py
@@ -18,7 +18,7 @@ from attestix.auth.crypto import (
     did_key_to_public_key,
 )
 from attestix.audit import AuditEventEmitter, resolve_emitter, safe_emit
-from attestix.config import load_credentials, save_credentials
+from attestix.config import append_credential, load_credentials, save_credentials
 from attestix.errors import ErrorCategory, log_and_format_error
 from attestix.signing import InProcessSigner, Signer
 from attestix.storage.repository import DEFAULT_TENANT
@@ -143,9 +143,11 @@ class CredentialService:
                 "proofValue": signature,
             }
 
-            data = load_credentials()
-            data["credentials"].append(credential)
-            save_credentials(data)
+            # Append-only write (issue #108): avoid the O(N) load+copy+rewrite of
+            # the whole credential store on every issuance. The on-disk shape is
+            # unchanged. revoke_credential still uses load/save (it mutates an
+            # existing record), so the read-modify-write path is untouched.
+            append_credential(credential)
 
             safe_emit(
                 self._emitter,

--- a/attestix/storage/file_repository.py
+++ b/attestix/storage/file_repository.py
@@ -17,8 +17,11 @@ record (no ``tenant_id``) is treated as tenant ``"default"`` (FR-013), and a cal
 that never sets a tenant uses ``"default"`` throughout (FR-014).
 """
 
+import atexit
+import os
 from copy import deepcopy
-from typing import List, Optional
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
 
 from attestix import config
 from attestix.storage.repository import DEFAULT_TENANT, Repository
@@ -74,6 +77,24 @@ def _tenant_of(record: dict) -> str:
     return record.get("tenant_id", DEFAULT_TENANT)
 
 
+#: Recognized durability modes (``durability`` arg / ``ATTESTIX_DURABILITY`` env).
+DURABILITY_SAFE = "safe"
+DURABILITY_FAST = "fast"
+_DURABILITY_MODES = (DURABILITY_SAFE, DURABILITY_FAST)
+
+
+def _resolve_durability(durability: Optional[str]) -> str:
+    """Resolve the effective durability mode (arg > env > ``safe`` default)."""
+    choice = durability or os.environ.get("ATTESTIX_DURABILITY") or DURABILITY_SAFE
+    choice = str(choice).strip().lower()
+    if choice not in _DURABILITY_MODES:
+        raise ValueError(
+            f"Unknown durability mode {choice!r}. "
+            f"Expected one of: {', '.join(_DURABILITY_MODES)}."
+        )
+    return choice
+
+
 class FileRepository(Repository):
     """JSON-file persistence reproducing v0.3.0 on-disk behavior.
 
@@ -82,7 +103,115 @@ class FileRepository(Repository):
     rename). This is the default backend: a fresh install with no configuration
     uses it, and ``config.load_*`` / ``config.save_*`` remain as thin public shims
     over the same helpers so external callers are unaffected.
+
+    Performance (issue #108)
+    ------------------------
+    A write-through *document cache* keeps the parsed JSON document for each file
+    in memory, validated against the file's ``(st_mtime_ns, st_size)`` so an
+    out-of-band write (another process, or a direct ``config._safe_save``) is
+    detected and the cache transparently reloaded. This removes the redundant
+    full-file *reads* that previously happened on every ``create`` / ``list`` /
+    ``_load_list`` — most importantly the audit-emit path, which read the whole
+    ``audit.json`` twice per event (once to find the chain head, once to append).
+    Paired with :meth:`append_to_document` (used by the credential issuance hot
+    path) and :meth:`last_record` (used by the audit emitter), a pure append no
+    longer copies the whole — and ever-growing — collection, so an N-append loop
+    is linear in N instead of quadratic. The on-disk format, file locations,
+    locking, and atomic-write guarantees are unchanged (FR-002, SC-001/SC-002).
+
+    Durability modes (issue #108)
+    -----------------------------
+    - ``"safe"`` (default): every mutating call flushes to disk immediately, with
+      the v0.3.0 backup + atomic-rename guarantees. No behavior change.
+    - ``"fast"``: opt-in batched durability for high-throughput issuance. Mutating
+      calls update the in-memory document and mark it dirty; the disk write is
+      deferred until :meth:`flush` or process exit (an ``atexit`` hook). This also
+      amortizes the per-write ``json.dump``, at the cost of losing at most the
+      un-flushed tail on a hard crash. Speed is therefore strictly opt-in; the
+      default stays crash-safe.
+
+    Select ``"fast"`` per instance (``FileRepository(durability="fast")``) or
+    process-wide via ``ATTESTIX_DURABILITY=fast``.
     """
+
+    def __init__(self, durability: Optional[str] = None) -> None:
+        self._durability = _resolve_durability(durability)
+        # file_path(str) -> (document, stat_token). stat_token is
+        # (st_mtime_ns, st_size) of the file the document was last read/written
+        # from, or None when the file did not exist at read time.
+        self._doc_cache: Dict[str, Tuple[dict, Optional[Tuple[int, int]]]] = {}
+        # file paths with un-flushed in-memory writes (fast mode only).
+        self._dirty: Set[str] = set()
+        if self._durability == DURABILITY_FAST:
+            # Best-effort: never lose a batched tail on a clean interpreter exit.
+            atexit.register(self.flush)
+
+    # --- document cache -------------------------------------------------------
+
+    @staticmethod
+    def _stat_token(file_path) -> Optional[Tuple[int, int]]:
+        """Return ``(st_mtime_ns, st_size)`` for ``file_path`` or ``None``."""
+        try:
+            st = os.stat(file_path)
+        except OSError:
+            return None
+        return (st.st_mtime_ns, st.st_size)
+
+    def _cached_document(self, file_path, default: dict) -> dict:
+        """Return the *live* cached document for ``file_path`` (reload if stale).
+
+        Returns the cache's own object (not a copy): internal callers mutate it in
+        place and then :meth:`_write_document` to persist. Public reads
+        (:meth:`load_document`, :meth:`get`, :meth:`list`) copy before returning so
+        the cache cannot be corrupted by a caller mutating a read result.
+        """
+        key = str(file_path)
+        cached = self._doc_cache.get(key)
+        if cached is not None:
+            doc, token = cached
+            # A dirty (un-flushed) document is authoritative regardless of disk.
+            if key in self._dirty:
+                return doc
+            # Otherwise trust the cache only while the file is byte-identical to
+            # what we last saw (cheap stat, not a full re-read).
+            if token == self._stat_token(file_path):
+                return doc
+        # Cold or stale: read through the shared safe loader (filelock + recovery).
+        doc = config._safe_load(file_path, default)
+        self._doc_cache[key] = (doc, self._stat_token(file_path))
+        self._dirty.discard(key)
+        return doc
+
+    def _write_document(self, file_path, data: dict) -> None:
+        """Persist ``data`` for ``file_path`` honoring the durability mode."""
+        key = str(file_path)
+        if self._durability == DURABILITY_FAST:
+            # Defer the disk write; the in-memory doc is authoritative until flush.
+            self._doc_cache[key] = (data, None)
+            self._dirty.add(key)
+            return
+        config._safe_save(file_path, data)
+        # Refresh the stat token to the just-written file so subsequent reads hit
+        # the cache instead of re-parsing.
+        self._doc_cache[key] = (data, self._stat_token(file_path))
+        self._dirty.discard(key)
+
+    def flush(self) -> None:
+        """Flush all pending in-memory writes to disk (no-op in ``safe`` mode).
+
+        Idempotent. Call this to make a batch of ``fast``-mode writes durable
+        without exiting the process (e.g. at the end of a bulk issuance run).
+        """
+        if not self._dirty:
+            return
+        for key in list(self._dirty):
+            doc, _ = self._doc_cache[key]
+            file_path = Path(key)
+            config._safe_save(file_path, doc)
+            self._doc_cache[key] = (doc, self._stat_token(file_path))
+        self._dirty.clear()
+
+    # --- document API (public shims back FR-002 load_*/save_* helpers) --------
 
     def load_document(self, collection: str) -> dict:
         """Load the entire JSON document for ``collection`` (whole-file load).
@@ -90,22 +219,67 @@ class FileRepository(Repository):
         This is the backing for ``config.load_*`` shims: it returns the same dict
         v0.3.0 ``load_*`` returned (the full document, default-populated), so
         external callers relying on the public ``config`` functions are unaffected.
+        Served from the document cache when the on-disk file is unchanged; a deep
+        copy is returned so a caller mutating the result cannot corrupt the cache
+        (the historical contract: each ``load_*`` returned a fresh dict).
         """
-        file_path, list_key, default = _resolve(collection)
-        return config._safe_load(file_path, default)
+        file_path, _, default = _resolve(collection)
+        return deepcopy(self._cached_document(file_path, default))
 
     def save_document(self, collection: str, data: dict) -> None:
         """Persist the entire JSON document for ``collection`` (whole-file save)."""
         file_path, _, _ = _resolve(collection)
-        config._safe_save(file_path, data)
+        self._write_document(file_path, data)
+
+    def append_to_document(self, collection: str, record: dict) -> dict:
+        """Append ``record`` to ``collection``'s primary list and persist (O(1)).
+
+        Performance (issue #108): the document API's :meth:`load_document` returns a
+        deep copy for caller isolation, so the historical
+        ``load -> list.append -> save`` issuance pattern paid an O(N) copy of the
+        whole (growing) collection on every single append — O(N^2) over a loop.
+        This appends one record directly to the *live* cached list and writes
+        through, so a pure append never copies the existing records.
+
+        Unlike :meth:`create`, the record is written **verbatim** (no ``tenant_id``
+        tagging), preserving the exact on-disk shape of the legacy document
+        collections (``credentials``, ``identities``, ...). Returns the stored
+        record (the same object that was appended).
+        """
+        data, records, file_path, _ = self._load_list(collection)
+        records.append(record)
+        self._save(file_path, data)
+        return record
+
+    def last_record(
+        self,
+        collection: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> Optional[dict]:
+        """Return the last record for ``tenant_id`` without copying the collection.
+
+        Hot-path accessor for append-chained collections (the audit log): the
+        emitter needs only the chain head to extend the chain, so copying the
+        entire (growing) event list on every emit — as a full :meth:`list` would —
+        is part of what made issuance O(N^2) (issue #108). Walks the live cached
+        list from the tail and returns a copy of just the one matching record (or
+        ``None``). Single-tenant (the self-host default) hits the last element
+        immediately.
+        """
+        _, records, _, _ = self._load_list(collection)
+        for rec in reversed(records):
+            if _tenant_of(rec) == tenant_id:
+                return deepcopy(rec)
+        return None
 
     def _load_list(self, collection: str):
         file_path, list_key, default = _resolve(collection)
-        data = config._safe_load(file_path, default)
+        data = self._cached_document(file_path, default)
         return data, data.setdefault(list_key, []), file_path, list_key
 
     def _save(self, file_path, data) -> None:
-        config._safe_save(file_path, data)
+        self._write_document(file_path, data)
 
     def create(
         self,
@@ -126,7 +300,8 @@ class FileRepository(Repository):
         stored["tenant_id"] = tenant_id
         records.append(stored)
         self._save(file_path, data)
-        return stored
+        # The stored dict is now owned by the cache; return a copy.
+        return deepcopy(stored)
 
     def get(
         self,
@@ -139,7 +314,8 @@ class FileRepository(Repository):
         _, records, _, _ = self._load_list(collection)
         for rec in records:
             if rec.get(id_field) == record_id and _tenant_of(rec) == tenant_id:
-                return rec
+                # Copy so a caller mutating the result cannot corrupt the cache.
+                return deepcopy(rec)
         return None
 
     def list(
@@ -158,7 +334,8 @@ class FileRepository(Repository):
                 continue
             if filters and any(rec.get(k) != v for k, v in filters.items()):
                 continue
-            results.append(rec)
+            # Copy so a caller mutating a result cannot corrupt the cache.
+            results.append(deepcopy(rec))
             if limit is not None and len(results) >= limit:
                 break
         return results
@@ -180,13 +357,15 @@ class FileRepository(Repository):
         data, records, file_path, _ = self._load_list(collection)
         for idx, rec in enumerate(records):
             if rec.get(id_field) == record_id and _tenant_of(rec) == tenant_id:
-                stored = dict(record)
+                # deepcopy so a caller mutating ``record`` after the call cannot
+                # reach into the cache through the shared reference.
+                stored = deepcopy(record)
                 # Persist the canonical id so an id-less payload stays queryable.
                 stored[id_field] = record_id
                 stored["tenant_id"] = tenant_id
                 records[idx] = stored
                 self._save(file_path, data)
-                return stored
+                return deepcopy(stored)
         return None
 
     def delete(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,7 @@ testpaths = ["tests"]
 addopts = "-p no:logfire"
 markers = [
     "live_blockchain: requires funded Base Sepolia wallet (deselect with -m 'not live_blockchain')",
+    "perf: performance guard tests (issuance scaling); generous CI thresholds (deselect with -m 'not perf')",
 ]
 
 [tool.ruff]

--- a/tests/perf/test_issuance_scales.py
+++ b/tests/perf/test_issuance_scales.py
@@ -1,0 +1,178 @@
+"""Performance guard for credential issuance scaling (issue #108).
+
+Before the fix, ``issue_credential`` did, per call, a full read + deep copy +
+rewrite of the whole (growing) ``credentials.json`` *and* two full reads + a
+rewrite of the whole ``audit.json`` — so an N-issuance loop was O(N^2) in bytes
+moved, measuring ~183 ms median per issuance at N=1000.
+
+The fix makes the append path O(1)-amortized:
+
+- :func:`attestix.config.append_credential` appends one record to the live
+  cached document instead of ``load -> deep-copy -> append -> rewrite``.
+- The audit emitter finds the chain head via
+  :meth:`FileRepository.last_record` instead of copying the whole event list.
+- An opt-in ``durability="fast"`` mode batches the disk writes so even the
+  per-write ``json.dump`` is amortized (the default ``safe`` mode stays
+  crash-safe and flushes every write).
+
+These tests guard against an O(N^2) regression. Timing assertions use generous
+thresholds so they are not flaky on shared CI, but tight enough that a return to
+quadratic behavior trips them. A deterministic (non-timing) guard backs them up.
+"""
+
+import time
+
+import pytest
+
+from attestix.audit import AuditEventEmitter, verify_chain
+from attestix.services.credential_service import CredentialService
+from attestix.storage import default_repository
+from attestix.storage.file_repository import FileRepository
+
+pytestmark = pytest.mark.perf
+
+
+@pytest.fixture
+def repo_factory(monkeypatch):
+    """Rebuild the process-default repositories under a chosen durability mode.
+
+    Saves and restores ``config._file_repository`` and ``storage._DEFAULT`` so a
+    fast-mode repo built for one test never leaks into the rest of the suite.
+    """
+    from attestix import config
+    import attestix.storage as storage
+
+    saved_cfg = config._file_repository
+    saved_default = storage._DEFAULT
+
+    def _build(mode: str):
+        monkeypatch.setenv("ATTESTIX_DURABILITY", mode)
+        config._file_repository = None  # rebuilt lazily by config._repo()
+        storage._DEFAULT = FileRepository()
+        return storage._DEFAULT
+
+    yield _build
+
+    config._file_repository = saved_cfg
+    storage._DEFAULT = saved_default
+
+
+def _issue_n(svc: CredentialService, n: int) -> None:
+    for i in range(n):
+        result = svc.issue_credential(
+            agent_id=f"did:key:zPerf{i}",
+            credential_type="AgentIdentityCredential",
+            issuer_name="VibeTensor",
+            claims={"n": i},
+        )
+        assert "error" not in result, result
+
+
+def test_issuing_200_is_fast_in_fast_mode(tmp_attestix, repo_factory):
+    """Fast (batched) durability issues 200 credentials well under 5s on CI."""
+    repo = repo_factory("fast")
+    svc = CredentialService()
+    start = time.perf_counter()
+    _issue_n(svc, 200)
+    repo.flush()
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 5.0, (
+        f"issuing 200 credentials took {elapsed:.2f}s in fast mode; "
+        f"expected < 5s (O(N^2) regression?)"
+    )
+
+
+def test_issuance_scales_near_linearly(tmp_attestix, repo_factory):
+    """Total issuance time must grow ~linearly, not quadratically, with N.
+
+    Quadratic growth would make the 4x-larger batch ~16x slower; linear ~4x. We
+    allow a very loose ceiling (9x) to absorb CI jitter and fixed per-call crypto
+    cost while still failing hard on a true O(N^2) regression.
+    """
+    def _time_for(n: int) -> float:
+        repo = repo_factory("fast")
+        svc = CredentialService()
+        start = time.perf_counter()
+        _issue_n(svc, n)
+        repo.flush()
+        return time.perf_counter() - start
+
+    small = max(_time_for(100), 1e-3)
+    large = _time_for(400)
+    ratio = large / small
+
+    assert ratio < 9.0, (
+        f"issuance time scaled {ratio:.1f}x from N=100 to N=400 "
+        f"(small={small:.3f}s large={large:.3f}s); near-linear is ~4x, "
+        f"quadratic would be ~16x — likely an O(N^2) regression"
+    )
+
+
+def test_issue_path_does_not_reload_whole_store(tmp_attestix):
+    """Deterministic guard: issuance must append, not load+rewrite the store.
+
+    A reload-the-whole-store-per-append implementation is exactly the O(N^2)
+    pattern this issue fixed. We assert the hot path calls ``append_to_document``
+    (O(1) append) and never ``load_document('credentials')`` (which deep-copies
+    the whole — growing — collection on every call).
+    """
+    from attestix import config
+
+    calls = {"append": 0, "load_credentials": 0}
+    real_append = config.append_credential
+    real_load = config.load_credentials
+
+    def spy_append(credential):
+        calls["append"] += 1
+        return real_append(credential)
+
+    def spy_load():
+        calls["load_credentials"] += 1
+        return real_load()
+
+    config.append_credential = spy_append
+    config.load_credentials = spy_load
+    # The service imported the names at module load; patch there too.
+    import attestix.services.credential_service as cs
+    cs.append_credential = spy_append
+    cs.load_credentials = spy_load
+    try:
+        svc = CredentialService()
+        for i in range(10):
+            svc.issue_credential(
+                agent_id=f"did:key:zSpy{i}",
+                credential_type="AgentIdentityCredential",
+                issuer_name="VibeTensor",
+                claims={"n": i},
+            )
+    finally:
+        config.append_credential = real_append
+        config.load_credentials = real_load
+        cs.append_credential = real_append
+        cs.load_credentials = real_load
+
+    assert calls["append"] == 10, "issuance should append once per credential"
+    assert calls["load_credentials"] == 0, (
+        "issuance must not load+copy the whole credential store per call "
+        "(O(N^2) regression)"
+    )
+
+
+@pytest.mark.parametrize("mode", ["safe", "fast"])
+def test_audit_chain_intact_after_bulk_issuance(tmp_attestix, repo_factory, mode):
+    """Both durability modes keep the audit chain verifiable end-to-end."""
+    repo = repo_factory(mode)
+    svc = CredentialService()
+    _issue_n(svc, 40)
+    # Flush both the audit default repo and the credential-store repo so the
+    # fast-mode tail is on disk before we read the chain back.
+    repo.flush()
+    from attestix import config
+    config._repo().flush()
+
+    emitter = AuditEventEmitter()
+    events = emitter.read_chain()
+    assert len(events) == 40
+    result = verify_chain(events)
+    assert result.valid, result.failure_reason


### PR DESCRIPTION
## What
Closes #108. Credential issuance was ~183 ms p50 (4.4 ops/s single-thread). Ed25519 signing is sub-millisecond — the cost was **I/O**: every `issue_credential` did a full read + deep-copy + rewrite of the whole (growing) `credentials.json` AND two full reads + a rewrite of `audit.json`. An N-issuance loop was **O(N²)** in bytes moved.

## Root cause (profiled)
The hot path was `load_credentials() → deep-copy → append → save_credentials()` on every single issuance, plus the audit emitter reading the entire event list to find the chain tail. Both grow with the store, so issuance #1000 moved ~1000× the bytes of issuance #1.

## Fix
- **`config.append_credential` → `FileRepository.append_to_document`**: appends one record to the live cached document instead of load → deep-copy → append → rewrite. **O(1) amortized.**
- **Audit emitter uses `FileRepository.last_record`** to find the chain head instead of copying the whole event list.
- **Opt-in `durability="fast"`** (`ATTESTIX_DURABILITY=fast`) batches disk writes so even the per-write `json.dump` is amortized. **Default `safe` mode is unchanged** — crash-safe, flushes every write, no behavior change for existing users.

## Guarantees preserved
- On-disk formats unchanged (`{"credentials":[...]}`, `audit.json` events) → `attestix import` of older bundles still works.
- File locking + atomic-write (`os.replace`) guarantees preserved.
- **`verify_chain` integrity holds in BOTH durability modes** (tested).

## Validation — `tests/perf/test_issuance_scales.py`, 5/5 pass in a clean venv
| Test | What it proves |
|---|---|
| `test_issuance_scales_near_linearly` | O(N²) regression guard — issuance time grows linearly, not quadratically |
| `test_issue_path_does_not_reload_whole_store` | **deterministic** (non-timing) proof the append path never reloads the whole store |
| `test_audit_chain_intact_after_bulk_issuance[safe]` | chain integrity in safe mode |
| `test_audit_chain_intact_after_bulk_issuance[fast]` | chain integrity in fast mode |
| `test_issuing_200_is_fast_in_fast_mode` | timing assertion (generous CI threshold) |

The timing thresholds are generous so the suite isn't flaky on shared CI, but tight enough that a return to quadratic behavior trips them. The deterministic `test_issue_path_does_not_reload_whole_store` is the load-bearing proof — it doesn't depend on wall-clock at all.

## Test plan
- New `tests/perf/` (5 tests) + `perf` marker registered in `pyproject.toml` (`-m 'not perf'` to skip).
- Full existing suite stays green.
- No new runtime dependencies. No on-disk format change.
