### PR TITLE
feat(website): client-side credential verification portal at /verify (closes #35)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/postcss": "^4.1.11",
+        "@vibetensor/attestix": "^0.2.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cobe": "^0.6.5",
@@ -109,6 +110,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -724,6 +726,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -746,6 +749,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -768,6 +772,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -784,6 +789,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -800,6 +806,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -816,6 +823,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -832,6 +840,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -848,6 +857,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -864,6 +874,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -880,6 +891,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -896,6 +908,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -912,6 +925,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -928,6 +942,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -950,6 +965,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -972,6 +988,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -994,6 +1011,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1016,6 +1034,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1038,6 +1057,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1060,6 +1080,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1082,6 +1103,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1104,6 +1126,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1123,6 +1146,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1142,6 +1166,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1161,6 +1186,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1419,6 +1445,33 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3964,6 +4017,18 @@
       "optionalDependencies": {
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vibetensor/attestix": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vibetensor/attestix/-/attestix-0.2.0.tgz",
+      "integrity": "sha512-qj6m0fis4a1X9gopzu+lI/rJgXsJDBMUgRsHLFjj5roAWBoaFoZBkcMoQdvu1uWxw/af56k8MNAPK+k+a9KTzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/acorn": {

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/postcss": "^4.1.11",
+    "@vibetensor/attestix": "^0.2.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cobe": "^0.6.5",

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -15,6 +15,7 @@ Attestix provides verifiable identity, W3C credentials, delegation chains, compl
 - [Blog](https://attestix.io/blog): Release notes and field reports
 - [Research](https://attestix.io/research): Paper abstract, contributions, evaluation
 - [Changelog](https://attestix.io/changelog): v0.1.0 through v0.3.0 release history
+- [Verify a credential](https://attestix.io/verify): Client-side W3C Verifiable Credential verifier — paste or drop a VC and check its Ed25519 signature, structure, and validity window entirely in-browser via the @vibetensor/attestix npm package. Nothing uploaded; no backend. By-id deep link form is /verify?id=<credential-id> (by-id resolution itself is an Attestix Cloud feature). Live revocation not checked offline.
 - [Security](https://attestix.io/security): Responsible disclosure, CVE process
 - [SBOM](https://attestix.io/sbom): Software bill of materials with licenses
 - [United Kingdom](https://attestix.io/uk): UK geo-landing — FCA, ICO, Bank of England framings for AI-Act-grade evidence

--- a/website/scripts/verify-samples.mjs
+++ b/website/scripts/verify-samples.mjs
@@ -1,0 +1,46 @@
+// Standalone validation harness for the /verify portal embedded samples.
+//
+// Proves the two embedded fixtures behave exactly as the UI claims:
+//   - sample-valid-vc.json    -> verifyCredential(...).valid === true
+//   - sample-tampered-vc.json -> verifyCredential(...).valid === false
+//
+// Run:  node scripts/verify-samples.mjs
+//
+// It imports the SAME JSON fixtures the browser page embeds and the SAME
+// @vibetensor/attestix verifier the page calls, so a green result here is the
+// same green result a visitor sees in the portal.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { verifyCredential } from "@vibetensor/attestix";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const load = (name) =>
+  JSON.parse(readFileSync(resolve(here, "..", "src", "lib", "samples", name), "utf-8"));
+
+const validVc = load("sample-valid-vc.json");
+const tamperedVc = load("sample-tampered-vc.json");
+
+let failures = 0;
+
+function check(label, vc, expectValid) {
+  const result = verifyCredential(vc);
+  const ok = result.valid === expectValid;
+  if (!ok) failures += 1;
+  console.log(`${ok ? "PASS" : "FAIL"}  ${label}`);
+  console.log(`      valid=${result.valid} expected=${expectValid}`);
+  console.log(`      reason=${result.reason ?? "(none)"}`);
+  console.log(
+    `      checks=${JSON.stringify(result.checks)} issuer=${result.issuer ?? "?"}`
+  );
+}
+
+check("valid sample -> valid", validVc, true);
+check("tampered sample -> invalid", tamperedVc, false);
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll sample checks passed.");

--- a/website/src/app/(marketing)/verify/page.tsx
+++ b/website/src/app/(marketing)/verify/page.tsx
@@ -1,0 +1,223 @@
+import { AtxEyebrow } from "@/components/atx/atx-eyebrow";
+import { constructMetadata } from "@/lib/utils";
+import Link from "next/link";
+import { VerifyClient } from "./verify-client";
+
+export const metadata = constructMetadata({
+  title: "Verify a credential",
+  description:
+    "Verify an Attestix-issued W3C Verifiable Credential in your browser. Ed25519 over JCS-canonical form, did:key resolution — fully client-side. Your credential is never uploaded.",
+});
+
+const NPM_PKG = "@vibetensor/attestix";
+
+export default function VerifyPage() {
+  return (
+    <section className="mx-auto max-w-[1080px] px-7 py-24">
+      <AtxEyebrow>Verification portal</AtxEyebrow>
+      <h1 className="mt-3 font-serif text-[clamp(36px,4.8vw,60px)] leading-[1.05] tracking-[-0.012em] text-atx-ink">
+        Verify an Attestix credential —
+        <br />
+        <em className="italic text-atx-accent">in your browser, nothing uploaded.</em>
+      </h1>
+      <p className="mt-6 max-w-[760px] text-[15px] leading-[1.65] text-atx-ink-mid">
+        Paste a W3C Verifiable Credential, or drop a{" "}
+        <code className="font-mono-atx text-[13px] text-atx-ink">.json</code> file.
+        The signature is checked entirely on this page using the published{" "}
+        <a
+          href={`https://www.npmjs.com/package/${NPM_PKG}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-mono-atx text-[13px] text-atx-accent hover:underline"
+        >
+          {NPM_PKG}
+        </a>{" "}
+        verifier. No installation, no account, no backend — your credential never
+        leaves your machine. That is a stronger trust story than a server-side
+        verifier: there is nothing to log, nothing to intercept, and nothing to
+        trust beyond the open-source code running in your own browser tab.
+      </p>
+
+      {/* Interactive verifier (client component) -------------------------- */}
+      <VerifyClient />
+
+      {/* ----- How this works --------------------------------------------- */}
+      <h2 className="mt-20 font-mono-atx text-[11px] uppercase tracking-[0.14em] text-atx-ink-dim">
+        01 / How this works
+      </h2>
+      <p className="mt-3 max-w-[760px] text-[14px] leading-[1.7] text-atx-ink-mid">
+        Attestix credentials carry an{" "}
+        <code className="font-mono-atx text-[12.5px] text-atx-ink">
+          Ed25519Signature2020
+        </code>{" "}
+        proof. To verify one, the page:
+      </p>
+      <ol className="mt-4 max-w-[760px] list-decimal space-y-2 pl-5 text-[14px] leading-[1.7] text-atx-ink-mid">
+        <li>
+          Strips the mutable{" "}
+          <code className="font-mono-atx text-[12.5px] text-atx-ink">proof</code>{" "}
+          and{" "}
+          <code className="font-mono-atx text-[12.5px] text-atx-ink">
+            credentialStatus
+          </code>{" "}
+          fields, then re-serialises the remainder to its JCS-canonical byte form
+          (sorted keys, tightest separators, NFC-normalised).
+        </li>
+        <li>
+          Resolves the issuer&apos;s public key from the{" "}
+          <code className="font-mono-atx text-[12.5px] text-atx-ink">did:key</code>{" "}
+          embedded in the proof&apos;s{" "}
+          <code className="font-mono-atx text-[12.5px] text-atx-ink">
+            verificationMethod
+          </code>{" "}
+          (the key is self-certifying — it is the public key, multibase-encoded).
+        </li>
+        <li>
+          Verifies the Ed25519 signature over those canonical bytes via{" "}
+          <code className="font-mono-atx text-[12.5px] text-atx-ink">
+            @noble/curves
+          </code>
+          , checks the credential structure, and compares the validity window
+          against your browser&apos;s clock.
+        </li>
+      </ol>
+      <p className="mt-4 max-w-[760px] text-[14px] leading-[1.7] text-atx-ink-mid">
+        Every step runs in a WebAssembly-free, pure-JavaScript crypto path inside
+        your tab. The same verifier ships in the{" "}
+        <a
+          href={`https://www.npmjs.com/package/${NPM_PKG}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-atx-accent hover:underline"
+        >
+          {NPM_PKG}
+        </a>{" "}
+        npm package and is byte-compatible with the Python{" "}
+        <a
+          href="https://pypi.org/project/attestix/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-atx-accent hover:underline"
+        >
+          attestix
+        </a>{" "}
+        core. The canonicalisation rules are documented in the{" "}
+        <Link href="/spec/bundle/v1" className="text-atx-accent hover:underline">
+          bundle wire-format spec
+        </Link>
+        .
+      </p>
+
+      {/* ----- Honest limitations ----------------------------------------- */}
+      <h2 className="mt-16 font-mono-atx text-[11px] uppercase tracking-[0.14em] text-atx-ink-dim">
+        02 / What offline verification proves — and what it doesn&apos;t
+      </h2>
+      <div className="mt-6 grid gap-5 md:grid-cols-2">
+        <div className="rounded-atx-md border border-atx-ok/30 bg-atx-ok/[0.06] p-5">
+          <div className="font-mono-atx text-[10.5px] uppercase tracking-[0.14em] text-atx-ok">
+            Proven offline
+          </div>
+          <ul className="mt-3 space-y-2 text-[13.5px] leading-[1.65] text-atx-ink-mid">
+            <li>
+              <strong className="text-atx-ink">Signature authenticity.</strong>{" "}
+              The credential was signed by the private key matching the issuer
+              DID, and not modified since — any tampered field breaks the
+              signature.
+            </li>
+            <li>
+              <strong className="text-atx-ink">Structural validity.</strong>{" "}
+              The document is a well-formed W3C VC with the required fields.
+            </li>
+            <li>
+              <strong className="text-atx-ink">Validity window.</strong>{" "}
+              Whether the credential is within its{" "}
+              <code className="font-mono-atx text-[12px] text-atx-ink">
+                issuanceDate
+              </code>
+              –
+              <code className="font-mono-atx text-[12px] text-atx-ink">
+                expirationDate
+              </code>{" "}
+              range, compared against your clock at view time.
+            </li>
+          </ul>
+        </div>
+        <div className="rounded-atx-md border border-atx-warn/40 bg-atx-warn/[0.06] p-5">
+          <div className="font-mono-atx text-[10.5px] uppercase tracking-[0.14em] text-atx-warn">
+            NOT proven offline
+          </div>
+          <ul className="mt-3 space-y-2 text-[13.5px] leading-[1.65] text-atx-ink-mid">
+            <li>
+              <strong className="text-atx-ink">Live revocation.</strong>{" "}
+              Offline mode reads only the{" "}
+              <code className="font-mono-atx text-[12px] text-atx-ink">
+                credentialStatus
+              </code>{" "}
+              embedded in the document. Checking the issuer&apos;s status list in
+              real time is a hosted lookup (an{" "}
+              <Link href="/pricing" className="text-atx-accent hover:underline">
+                Attestix Cloud
+              </Link>{" "}
+              feature). A signature can be valid and the credential still revoked.
+            </li>
+            <li>
+              <strong className="text-atx-ink">Issuer identity.</strong>{" "}
+              A <code className="font-mono-atx text-[12px] text-atx-ink">did:key</code>{" "}
+              is self-certifying — it proves control of a key, not who controls
+              it. <code className="font-mono-atx text-[12px] text-atx-ink">did:web</code>{" "}
+              binds a DID to a domain; <code className="font-mono-atx text-[12px] text-atx-ink">did:key</code>{" "}
+              does not. Establish out-of-band that the DID belongs to the party
+              you expect.
+            </li>
+            <li>
+              <strong className="text-atx-ink">By-id lookup.</strong>{" "}
+              Resolving a credential from just its id needs the hosted API; this
+              static page has no store to resolve against.
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* ----- See also ---------------------------------------------------- */}
+      <div className="mt-14 rounded-atx-md border border-atx-line-soft bg-atx-bg-sunken p-6">
+        <div className="font-mono-atx text-[10.5px] uppercase tracking-[0.14em] text-atx-ink-dim">
+          See also
+        </div>
+        <div className="mt-2 flex flex-wrap gap-4 text-[13.5px]">
+          <a
+            href={`https://www.npmjs.com/package/${NPM_PKG}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-atx-accent hover:underline"
+          >
+            {NPM_PKG} (npm verifier)
+          </a>
+          <Link href="/spec/bundle/v1" className="text-atx-accent hover:underline">
+            Bundle wire format v1
+          </Link>
+          <Link href="/security" className="text-atx-accent hover:underline">
+            Security
+          </Link>
+          <Link href="/docs/guides/offline-verify" className="text-atx-accent hover:underline">
+            Offline verification docs
+          </Link>
+        </div>
+        <p className="mt-4 text-[12.5px] leading-[1.6] text-atx-ink-dim">
+          Attestix is evidence tooling, not a guarantor of compliance. A green
+          result proves the credential&apos;s signature and structure — it does
+          not by itself establish that the issuer was authorised to make the
+          claims, nor that the subject is compliant. Maintained by{" "}
+          <a
+            href="https://vibetensor.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-atx-accent hover:underline"
+          >
+            VibeTensor
+          </a>
+          .
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/website/src/app/(marketing)/verify/verify-client.tsx
+++ b/website/src/app/(marketing)/verify/verify-client.tsx
@@ -1,0 +1,627 @@
+"use client";
+
+import {
+  SAMPLE_TAMPERED_VC_TEXT,
+  SAMPLE_VALID_VC_TEXT,
+} from "@/lib/verify-samples";
+import {
+  canonicalize,
+  verifyCredential,
+  type JsonValue,
+} from "@vibetensor/attestix";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Everything below runs ENTIRELY in the visitor's browser. There is no fetch(),
+// no API call, no telemetry. The pasted credential never leaves the machine.
+// The only crypto is the published @vibetensor/attestix verifier (Ed25519 over
+// JCS-canonical bytes via @noble/curves) — we do not reimplement any of it.
+// ---------------------------------------------------------------------------
+
+type Outcome = "valid" | "invalid" | "malformed";
+
+interface CredentialChecks {
+  structure_valid: boolean;
+  signature_valid: boolean;
+  not_expired: boolean;
+  not_revoked: boolean;
+}
+
+interface Report {
+  outcome: Outcome;
+  reason?: string;
+  checks?: CredentialChecks;
+  issuer?: string;
+  issuerName?: string;
+  subject?: string;
+  type?: string[];
+  verificationMethod?: string;
+  didMethod?: string;
+  issuanceDate?: string;
+  expirationDate?: string;
+  expired?: boolean;
+  subjectClaims?: Array<{ key: string; value: string }>;
+  status?: { type?: string; revoked?: boolean; id?: string };
+  canonicalHash?: string;
+}
+
+const SUPPORTED_DID_METHODS = ["did:key", "did:web"];
+
+function didMethodOf(did?: string): string | undefined {
+  if (!did) return undefined;
+  const parts = did.split(":");
+  if (parts.length >= 2 && parts[0] === "did") return `did:${parts[1]}`;
+  return undefined;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function stringifyClaim(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export function VerifyClient() {
+  const [text, setText] = useState("");
+  const [deepLinkId, setDeepLinkId] = useState<string | undefined>(undefined);
+  const [report, setReport] = useState<Report | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const runVerify = useCallback(async (raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      setReport(null);
+      return;
+    }
+
+    let vc: Record<string, unknown>;
+    try {
+      vc = JSON.parse(trimmed);
+    } catch {
+      setReport({
+        outcome: "malformed",
+        reason:
+          "This doesn't look like valid JSON. Paste the full Verifiable Credential, including the surrounding { } and the proof block.",
+      });
+      return;
+    }
+
+    if (typeof vc !== "object" || vc === null || Array.isArray(vc)) {
+      setReport({
+        outcome: "malformed",
+        reason:
+          "This JSON is not a credential object. A W3C VC is a JSON object with a credentialSubject and a proof.",
+      });
+      return;
+    }
+
+    const proof = vc.proof as Record<string, unknown> | undefined;
+    if (!proof) {
+      setReport({
+        outcome: "malformed",
+        reason:
+          "No signature present — this credential has no `proof` block, so there is nothing to verify. An unsigned document carries no cryptographic assurance.",
+      });
+      return;
+    }
+
+    const verificationMethod =
+      typeof proof.verificationMethod === "string"
+        ? proof.verificationMethod
+        : undefined;
+    const issuerObj = vc.issuer as Record<string, unknown> | string | undefined;
+    const issuerId =
+      typeof issuerObj === "string"
+        ? issuerObj
+        : (issuerObj?.id as string | undefined);
+    const issuerDidForMethod =
+      verificationMethod?.split("#")[0] ?? issuerId;
+    const didMethod = didMethodOf(issuerDidForMethod);
+
+    if (didMethod && !SUPPORTED_DID_METHODS.includes(didMethod)) {
+      setReport({
+        outcome: "malformed",
+        reason: `This verifier supports ${SUPPORTED_DID_METHODS.join(
+          " and "
+        )}; this credential's issuer uses ${didMethod}, which cannot be resolved client-side here.`,
+        issuer: issuerId,
+        verificationMethod,
+        didMethod,
+      });
+      return;
+    }
+
+    let canonicalHash: string | undefined;
+    try {
+      // Hash the canonical bytes over the SIGNED field set (proof and the
+      // mutable credentialStatus removed) — the exact bytes the Ed25519
+      // signature covers. Lets a technical user cross-check independently.
+      const signedView: Record<string, unknown> = { ...vc };
+      delete signedView.proof;
+      delete signedView.credentialStatus;
+      canonicalHash = await sha256Hex(
+        canonicalize(signedView as unknown as JsonValue)
+      );
+    } catch {
+      // Non-fatal: canonicalisation can throw on values JCS rejects; the
+      // verifier below will surface the real reason.
+    }
+
+    let result: ReturnType<typeof verifyCredential>;
+    try {
+      result = verifyCredential(vc);
+    } catch (err) {
+      setReport({
+        outcome: "malformed",
+        reason:
+          err instanceof Error
+            ? err.message
+            : "The verifier could not process this document.",
+        canonicalHash,
+      });
+      return;
+    }
+
+    const subjectObj = vc.credentialSubject as
+      | Record<string, unknown>
+      | undefined;
+    const subjectClaims = subjectObj
+      ? Object.entries(subjectObj)
+          .filter(([k]) => k !== "id")
+          .map(([key, value]) => ({ key, value: stringifyClaim(value) }))
+      : [];
+
+    const status = vc.credentialStatus as Record<string, unknown> | undefined;
+    const expirationDate =
+      typeof vc.expirationDate === "string" ? vc.expirationDate : undefined;
+    const expired = expirationDate
+      ? new Date(expirationDate).getTime() < Date.now()
+      : false;
+
+    setReport({
+      outcome: result.valid ? "valid" : "invalid",
+      reason: result.reason,
+      checks: result.checks as unknown as CredentialChecks,
+      issuer: result.issuer ?? issuerId,
+      issuerName:
+        typeof issuerObj === "object"
+          ? (issuerObj?.name as string | undefined)
+          : undefined,
+      subject: result.subject ?? (subjectObj?.id as string | undefined),
+      type: result.type,
+      verificationMethod,
+      didMethod,
+      issuanceDate:
+        typeof vc.issuanceDate === "string" ? vc.issuanceDate : undefined,
+      expirationDate,
+      expired,
+      subjectClaims,
+      status: status
+        ? {
+            type: status.type as string | undefined,
+            revoked:
+              typeof status.revoked === "boolean"
+                ? (status.revoked as boolean)
+                : undefined,
+            id: status.id as string | undefined,
+          }
+        : undefined,
+      canonicalHash,
+    });
+  }, []);
+
+  // Honest handling of the /verify/<id> deep link: we cannot resolve a
+  // credential by id without the hosted API, so we never fake it — we surface
+  // the id and steer the visitor to the offline paste box.
+  const [showDeepLinkNotice, setShowDeepLinkNotice] = useState(false);
+  useEffect(() => {
+    // Read the by-id deep link client-side. Supports the query form
+    // /verify?id=<id> (the shipped form — query strings work in a static
+    // export without per-id pre-rendering). We never resolve the id; we only
+    // surface it and steer the visitor to the offline paste box.
+    if (typeof window === "undefined") return;
+    const id = new URLSearchParams(window.location.search).get("id");
+    if (id) {
+      setDeepLinkId(id);
+      setShowDeepLinkNotice(true);
+    }
+  }, []);
+
+  const onFile = useCallback(
+    (file: File) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const content = String(reader.result ?? "");
+        setText(content);
+        void runVerify(content);
+      };
+      reader.readAsText(file);
+    },
+    [runVerify]
+  );
+
+  return (
+    <div className="mt-10">
+      {showDeepLinkNotice && deepLinkId ? (
+        <div className="mb-8 rounded-atx-md border border-atx-warn/40 bg-atx-warn/[0.06] p-5">
+          <div className="font-mono-atx text-[10.5px] uppercase tracking-[0.14em] text-atx-warn">
+            By-id lookup
+          </div>
+          <p className="mt-2 text-[13.5px] leading-[1.65] text-atx-ink-mid">
+            You followed a link for credential{" "}
+            <code className="font-mono-atx text-[12px] text-atx-ink">
+              {deepLinkId}
+            </code>
+            . Resolving a credential by id requires a hosted lookup (an{" "}
+            <a
+              href="/pricing"
+              className="text-atx-accent hover:underline"
+            >
+              Attestix Cloud
+            </a>{" "}
+            workspace). This page is a static, zero-backend verifier, so there is
+            nothing to fetch the credential from. Paste the full credential JSON
+            below to verify it offline instead — the result is identical, and
+            nothing is uploaded.
+          </p>
+        </div>
+      ) : null}
+
+      {/* Input area --------------------------------------------------------- */}
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          const file = e.dataTransfer.files?.[0];
+          if (file) onFile(file);
+        }}
+        className={`rounded-atx-md border ${
+          dragging
+            ? "border-atx-accent bg-atx-accent/[0.05]"
+            : "border-atx-line-soft bg-atx-bg-sunken"
+        } p-4 transition-colors`}
+      >
+        <label
+          htmlFor="vc-input"
+          className="font-mono-atx text-[10.5px] uppercase tracking-[0.14em] text-atx-ink-dim"
+        >
+          Paste credential JSON · or drop a .json file
+        </label>
+        <textarea
+          id="vc-input"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          spellCheck={false}
+          placeholder='{ "@context": [...], "type": ["VerifiableCredential", ...], "issuer": {...}, "credentialSubject": {...}, "proof": {...} }'
+          className="mt-3 h-64 w-full resize-y rounded-atx-sm border border-atx-line-soft bg-atx-panel px-4 py-3 font-mono-atx text-[12.5px] leading-[1.55] text-atx-ink outline-none focus:border-atx-accent"
+        />
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void runVerify(text)}
+            className="rounded-atx-sm bg-atx-accent px-5 py-2 font-mono-atx text-[12px] font-medium uppercase tracking-[0.1em] text-atx-bg transition-opacity hover:opacity-90"
+          >
+            Verify
+          </button>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="rounded-atx-sm border border-atx-line-soft px-4 py-2 font-mono-atx text-[12px] uppercase tracking-[0.1em] text-atx-ink-mid hover:border-atx-accent hover:text-atx-ink"
+          >
+            Upload .json
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setText(SAMPLE_VALID_VC_TEXT);
+              void runVerify(SAMPLE_VALID_VC_TEXT);
+            }}
+            className="rounded-atx-sm border border-atx-line-soft px-4 py-2 font-mono-atx text-[12px] uppercase tracking-[0.1em] text-atx-ink-mid hover:border-atx-accent hover:text-atx-ink"
+          >
+            Load a sample
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setText(SAMPLE_TAMPERED_VC_TEXT);
+              void runVerify(SAMPLE_TAMPERED_VC_TEXT);
+            }}
+            className="rounded-atx-sm border border-atx-line-soft px-4 py-2 font-mono-atx text-[12px] uppercase tracking-[0.1em] text-atx-ink-mid hover:border-atx-warn hover:text-atx-warn"
+          >
+            Load a tampered sample
+          </button>
+          {text ? (
+            <button
+              type="button"
+              onClick={() => {
+                setText("");
+                setReport(null);
+              }}
+              className="rounded-atx-sm px-3 py-2 font-mono-atx text-[12px] uppercase tracking-[0.1em] text-atx-ink-dim hover:text-atx-ink"
+            >
+              Clear
+            </button>
+          ) : null}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json,application/json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) onFile(file);
+              e.target.value = "";
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Results ------------------------------------------------------------ */}
+      {report ? <ResultPanel report={report} /> : null}
+    </div>
+  );
+}
+
+function Badge({
+  pass,
+  pendingLabel,
+  passLabel,
+  failLabel,
+  state,
+}: {
+  pass?: boolean;
+  pendingLabel?: string;
+  passLabel: string;
+  failLabel: string;
+  state?: "pending";
+}) {
+  if (state === "pending") {
+    return (
+      <span className="rounded-atx-xs border border-atx-line-soft px-2 py-0.5 font-mono-atx text-[10.5px] uppercase tracking-[0.12em] text-atx-ink-dim">
+        {pendingLabel}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`rounded-atx-xs border px-2 py-0.5 font-mono-atx text-[10.5px] uppercase tracking-[0.12em] ${
+        pass
+          ? "border-atx-ok/40 bg-atx-ok/[0.08] text-atx-ok"
+          : "border-atx-err/40 bg-atx-err/[0.08] text-atx-err"
+      }`}
+    >
+      {pass ? passLabel : failLabel}
+    </span>
+  );
+}
+
+function Row({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1 border-b border-atx-line-soft px-5 py-3.5 sm:flex-row sm:items-start sm:gap-6">
+      <div className="w-44 shrink-0 font-mono-atx text-[10.5px] uppercase tracking-[0.14em] text-atx-ink-faint">
+        {label}
+      </div>
+      <div className="min-w-0 flex-1 break-words text-[13px] leading-[1.6] text-atx-ink-mid">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function ResultPanel({ report }: { report: Report }) {
+  const tone =
+    report.outcome === "valid"
+      ? {
+          border: "border-atx-ok/40",
+          bg: "bg-atx-ok/[0.05]",
+          text: "text-atx-ok",
+          label: "Valid",
+        }
+      : report.outcome === "invalid"
+        ? {
+            border: "border-atx-err/40",
+            bg: "bg-atx-err/[0.05]",
+            text: "text-atx-err",
+            label: "Invalid",
+          }
+        : {
+            border: "border-atx-warn/40",
+            bg: "bg-atx-warn/[0.05]",
+            text: "text-atx-warn",
+            label: "Malformed",
+          };
+
+  return (
+    <div className={`mt-8 overflow-hidden rounded-atx-md border ${tone.border}`}>
+      <div className={`flex items-center gap-3 ${tone.bg} px-5 py-4`}>
+        <span
+          className={`font-serif text-[26px] leading-none ${tone.text}`}
+          aria-hidden
+        >
+          {report.outcome === "valid"
+            ? "✓"
+            : report.outcome === "invalid"
+              ? "✗"
+              : "!"}
+        </span>
+        <div>
+          <div
+            className={`font-mono-atx text-[11px] uppercase tracking-[0.16em] ${tone.text}`}
+          >
+            {tone.label}
+          </div>
+          <div className="mt-0.5 text-[13px] text-atx-ink-mid">
+            {report.outcome === "valid"
+              ? "The signature is authentic and the credential is well-formed and within its validity window."
+              : report.outcome === "invalid"
+                ? report.reason ?? "Verification failed."
+                : report.reason ?? "This document could not be parsed as a credential."}
+          </div>
+        </div>
+      </div>
+
+      {report.outcome !== "malformed" ? (
+        <div className="bg-atx-panel">
+          {report.checks ? (
+            <Row label="Signature">
+              <span className="inline-flex flex-wrap items-center gap-3">
+                <Badge
+                  pass={report.checks.signature_valid}
+                  passLabel="Ed25519 verified"
+                  failLabel="Signature failed"
+                />
+                {report.verificationMethod ? (
+                  <code className="font-mono-atx text-[11.5px] text-atx-ink-dim">
+                    {report.verificationMethod}
+                  </code>
+                ) : null}
+              </span>
+            </Row>
+          ) : null}
+
+          {report.checks ? (
+            <Row label="Structure">
+              <Badge
+                pass={report.checks.structure_valid}
+                passLabel="Well-formed VC"
+                failLabel="Malformed"
+              />
+            </Row>
+          ) : null}
+
+          <Row label="Issuer">
+            <div className="flex flex-col gap-0.5">
+              {report.issuerName ? (
+                <span className="text-atx-ink">{report.issuerName}</span>
+              ) : null}
+              <code className="font-mono-atx text-[11.5px] text-atx-ink-dim">
+                {report.issuer ?? "—"}
+              </code>
+            </div>
+          </Row>
+
+          <Row label="Subject">
+            <div className="flex flex-col gap-1">
+              <code className="font-mono-atx text-[11.5px] text-atx-ink-dim">
+                {report.subject ?? "—"}
+              </code>
+              {report.subjectClaims && report.subjectClaims.length > 0 ? (
+                <div className="mt-1 flex flex-col gap-1">
+                  {report.subjectClaims.map((c) => (
+                    <div key={c.key} className="flex gap-2 text-[12.5px]">
+                      <span className="font-mono-atx text-atx-ink-faint">
+                        {c.key}
+                      </span>
+                      <span className="text-atx-ink-mid">{c.value}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </Row>
+
+          {report.type && report.type.length > 0 ? (
+            <Row label="Type">
+              <span className="font-mono-atx text-[12px] text-atx-ink-mid">
+                {report.type.join(", ")}
+              </span>
+            </Row>
+          ) : null}
+
+          <Row label="Validity window">
+            <div className="flex flex-col gap-1">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="font-mono-atx text-[12px] text-atx-ink-dim">
+                  issued {report.issuanceDate ?? "—"}
+                </span>
+                {report.expirationDate ? (
+                  <span className="font-mono-atx text-[12px] text-atx-ink-dim">
+                    expires {report.expirationDate}
+                  </span>
+                ) : null}
+              </div>
+              {report.expirationDate ? (
+                <Badge
+                  pass={!report.expired}
+                  passLabel="Within validity window"
+                  failLabel="Expired"
+                />
+              ) : (
+                <span className="font-mono-atx text-[11.5px] text-atx-ink-faint">
+                  no expirationDate declared
+                </span>
+              )}
+            </div>
+          </Row>
+
+          <Row label="Revocation">
+            {report.status?.revoked === true ? (
+              <Badge pass={false} passLabel="" failLabel="Declared revoked" />
+            ) : report.status ? (
+              <div className="flex flex-col gap-1">
+                <Badge state="pending" pendingLabel="Status list not checked (offline)" passLabel="" failLabel="" />
+                <span className="text-[12.5px] leading-[1.55] text-atx-ink-mid">
+                  This credential declares a{" "}
+                  <code className="font-mono-atx text-[11.5px] text-atx-ink">
+                    {report.status.type ?? "credentialStatus"}
+                  </code>{" "}
+                  endpoint{report.status.id ? " " : ""}
+                  {report.status.id ? (
+                    <code className="font-mono-atx text-[11.5px] text-atx-ink-dim">
+                      {report.status.id}
+                    </code>
+                  ) : null}
+                  . Its <code className="font-mono-atx text-[11.5px] text-atx-ink">revoked</code>{" "}
+                  flag reads{" "}
+                  <code className="font-mono-atx text-[11.5px] text-atx-ink">
+                    {String(report.status.revoked)}
+                  </code>{" "}
+                  in the document, but a live revocation check against the
+                  issuer&apos;s status list is a hosted lookup and is not
+                  performed in this offline verifier.
+                </span>
+              </div>
+            ) : (
+              <span className="text-[12.5px] text-atx-ink-mid">
+                No <code className="font-mono-atx text-[11.5px] text-atx-ink">credentialStatus</code>{" "}
+                present — this credential carries no revocation endpoint to check.
+              </span>
+            )}
+          </Row>
+
+          {report.canonicalHash ? (
+            <Row label="Canonical form">
+              <div className="flex flex-col gap-1">
+                <span className="text-[12px] text-atx-ink-mid">
+                  SHA-256 of the JCS-canonical signed bytes (proof and
+                  credentialStatus removed):
+                </span>
+                <code className="break-all font-mono-atx text-[11.5px] text-atx-accent">
+                  {report.canonicalHash}
+                </code>
+              </div>
+            </Row>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -111,6 +111,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "yearly",
       priority: 0.8,
     },
+    {
+      // Client-side W3C VC verification portal. Anyone can verify an
+      // Attestix-issued credential in-browser with nothing uploaded; the
+      // shareable by-id form is /verify?id=<credential-id>.
+      url: `${siteConfig.url}/verify`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
     ...docsRoutes,
     ...blogRoutes,
   ];

--- a/website/src/lib/samples/sample-tampered-vc.json
+++ b/website/src/lib/samples/sample-tampered-vc.json
@@ -1,0 +1,39 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ],
+  "id": "urn:uuid:fd2ab479-da9f-4cec-959e-c9a6c0e1f116",
+  "type": [
+    "VerifiableCredential",
+    "EUAIActComplianceCredential"
+  ],
+  "issuer": {
+    "id": "did:key:z6Mkija7eQS9kNrvh1kAp7PJFgPEznFpBdDm825vugSQxdW7",
+    "name": "VibeTensor"
+  },
+  "issuanceDate": "2026-05-30T02:58:42.816449+00:00",
+  "expirationDate": "2027-05-30T02:58:42.816449+00:00",
+  "credentialSubject": {
+    "id": "attestix:9648678826a049b4",
+    "compliant": true,
+    "risk_level": "low",
+    "article_43_assessment": "passed",
+    "annex_iii_category": "8 - Administration of justice",
+    "notified_body": "NB-0482 Notified Body",
+    "anchor_network": "Base Sepolia testnet"
+  },
+  "credentialStatus": {
+    "type": "AttestixRevocationStatus",
+    "revoked": false,
+    "revocation_reason": null,
+    "revoked_at": null
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-30T02:58:42.816449+00:00",
+    "verificationMethod": "did:key:z6Mkija7eQS9kNrvh1kAp7PJFgPEznFpBdDm825vugSQxdW7#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "AD7KznyeJv8xr9G9R4mKAyL0MZCkvM7wrghxP6yFxpyzvEUyRhh96jtDNFTzXjy8L1v4alN3GBk-5HJvytpuCw=="
+  }
+}

--- a/website/src/lib/samples/sample-valid-vc.json
+++ b/website/src/lib/samples/sample-valid-vc.json
@@ -1,0 +1,39 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ],
+  "id": "urn:uuid:fd2ab479-da9f-4cec-959e-c9a6c0e1f116",
+  "type": [
+    "VerifiableCredential",
+    "EUAIActComplianceCredential"
+  ],
+  "issuer": {
+    "id": "did:key:z6Mkija7eQS9kNrvh1kAp7PJFgPEznFpBdDm825vugSQxdW7",
+    "name": "VibeTensor"
+  },
+  "issuanceDate": "2026-05-30T02:58:42.816449+00:00",
+  "expirationDate": "2027-05-30T02:58:42.816449+00:00",
+  "credentialSubject": {
+    "id": "attestix:9648678826a049b4",
+    "compliant": true,
+    "risk_level": "high",
+    "article_43_assessment": "passed",
+    "annex_iii_category": "8 - Administration of justice",
+    "notified_body": "NB-0482 Notified Body",
+    "anchor_network": "Base Sepolia testnet"
+  },
+  "credentialStatus": {
+    "type": "AttestixRevocationStatus",
+    "revoked": false,
+    "revocation_reason": null,
+    "revoked_at": null
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-30T02:58:42.816449+00:00",
+    "verificationMethod": "did:key:z6Mkija7eQS9kNrvh1kAp7PJFgPEznFpBdDm825vugSQxdW7#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "AD7KznyeJv8xr9G9R4mKAyL0MZCkvM7wrghxP6yFxpyzvEUyRhh96jtDNFTzXjy8L1v4alN3GBk-5HJvytpuCw=="
+  }
+}

--- a/website/src/lib/verify-samples.ts
+++ b/website/src/lib/verify-samples.ts
@@ -1,0 +1,23 @@
+// Embedded "try it" fixtures for the /verify portal.
+//
+// SAMPLE_VALID_VC is a genuine, Ed25519-signed W3C Verifiable Credential issued
+// by the Python `attestix` core (issuer DID
+// did:key:z6Mkija7eQS9kNrvh1kAp7PJFgPEznFpBdDm825vugSQxdW7, name VibeTensor). It
+// verifies green under the same @vibetensor/attestix verifier the page imports.
+//
+// SAMPLE_TAMPERED_VC is the identical credential with one signed field mutated
+// (credentialSubject.risk_level "high" -> "low") while the original proofValue
+// is left in place. Because the signature no longer covers the body, the
+// verifier reports INVALID — demonstrating tamper detection.
+//
+// Both fixtures are validated in CI-style by scripts/verify-samples.mjs, which
+// imports the exact same JSON and runs verifyCredential against it.
+
+import sampleValid from "./samples/sample-valid-vc.json";
+import sampleTampered from "./samples/sample-tampered-vc.json";
+
+export const SAMPLE_VALID_VC: Record<string, unknown> = sampleValid;
+export const SAMPLE_TAMPERED_VC: Record<string, unknown> = sampleTampered;
+
+export const SAMPLE_VALID_VC_TEXT = JSON.stringify(sampleValid, null, 2);
+export const SAMPLE_TAMPERED_VC_TEXT = JSON.stringify(sampleTampered, null, 2);


### PR DESCRIPTION
Closes #35

## What

A browser page at **`/verify`** where anyone — a regulator (ICP6), a customer, or an auditor — can verify an Attestix-issued W3C Verifiable Credential **without installing anything**. Paste the VC JSON or drop a `.json` file; the signature is checked **entirely in the browser** via the published `@vibetensor/attestix` verifier (Ed25519 over JCS-canonical form + `did:key` resolution, `@noble/curves` under the hood). The credential **never leaves the user's machine** — no backend, no `fetch()`, no telemetry. That is a stronger trust story than a server-side verifier, and the page says so.

## Route decision: `/verify` + `/verify?id=` (not `/verify/[id]`)

The site is a static Cloudflare Pages export (`output: "export"`). A path segment `/verify/[id]` cannot work for unbounded credential ids — static export pre-renders only enumerable `generateStaticParams`, and we deliberately do **not** fake a by-id resolver (by-id resolution needs the hosted Attestix Cloud API). Query strings need no pre-rendering and work in a static export, so the shareable by-id form is **`/verify?id=<credential-id>`**. The page reads `?id=` client-side and shows a notice that by-id lookup needs an Attestix Cloud workspace, offering the offline paste box as the alternative. No resolver is faked.

## Results panel (all client-side)

Overall **VALID / INVALID / MALFORMED**; Ed25519 signature result + `verificationMethod`; issuer DID/name; subject id + claims; validity window with an `expired?` badge computed at view time; revocation handled **honestly** (if `credentialStatus` is present we show it but never claim "not revoked" — live revocation is a cloud feature); and the SHA-256 of the JCS-canonical *signed* bytes for independent cross-checking.

**Try-it samples:** "Load a sample" embeds a genuinely-valid VibeTensor-issued VC (Base Sepolia testnet only); "Load a tampered sample" embeds the same VC with one signed field mutated so the signature fails — demonstrating tamper detection.

## Manual verifier validation

`scripts/verify-samples.mjs` imports the **same** `@vibetensor/attestix` `verifyCredential` the page uses and runs it against the **same** embedded JSON fixtures:

```
PASS  valid sample -> valid
      valid=true reason=(none)
      checks={"structure_valid":true,"signature_valid":true,"not_expired":true,"not_revoked":true}
      issuer=did:key:z6Mkija7eQS9kNrvh1kAp7PJFgPEznFpBdDm825vugSQxdW7
PASS  tampered sample -> invalid
      valid=false reason="Invalid signature"
      checks={"structure_valid":true,"signature_valid":false,"not_expired":true,"not_revoked":true}
```

Headless-browser smoke test against the static export confirmed the UI matches: valid sample shows "Ed25519 verified" + "Within validity window"; tampered shows "Signature failed"; `/verify?id=` shows the by-id notice; **zero console errors**.

## Honest limitations documented on the page

Offline verification proves signature authenticity + structure + validity window, but **NOT** live revocation (needs the issuer status endpoint / Attestix Cloud) and **NOT** issuer identity beyond the DID's self-certification (`did:web` adds domain binding; `did:key` is self-certifying). Footer: "evidence tooling, not a guarantor of compliance".

## Discipline

- 100% client-side: no backend, no API calls, no telemetry.
- The only crypto dependency is the published `@vibetensor/attestix` package — no reimplemented Ed25519/JCS.
- VibeTensor branding; Base Sepolia testnet only in the sample.
- v2 design system, mirroring `/spec/bundle/v1`.

## Build / test

- `npx tsc --noEmit` — clean (verify-portal files).
- `npx next build` — clean static export. **73 exported HTML pages** (was 72; +`/verify`).
- `/verify` registered in `sitemap.ts` and `public/llms.txt`.

> Note on the npm package: the unscoped `attestix` npm name is not yet published (404); the published verifier is `@vibetensor/attestix@0.2.0` (1 dep: `@noble/curves`, isomorphic / browser-safe), consistent with the existing `/spec/bundle/v1` page's "unscoped attestix publish in flight" note. Swapping to the unscoped name later is a one-line import change.

> Base note: this branch is cut from `8b1dade` (the commit referenced in the task as latest `main`) for a clean, buildable diff. Current `main` HEAD (`87a8152`, a Dependabot bump #90) upgrades Next to 16 + fumadocs-core/ui to 16 while leaving `fumadocs-mdx` at 15, which breaks the docs build independently of this PR (the `fumadocs-mdx/runtime/next` import path changed in v16) — see the project's "do not upgrade to Fumadocs v16" guidance. Rebasing this PR onto a fixed `main` is trivial (no conflicts; my only dependency change is one added line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
