### PR TITLE
release(0.4.0-rc.4): fix 4 blockers from the Linux 10-persona validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,65 @@ All notable changes to Attestix are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.0-rc.4] - 2026-05-30
+
+Honest follow-up to rc.3. The internal Linux RC validation report
+(source-blind 10-persona harness run inside WSL Ubuntu 24.04 / CPython
+3.12 against the published `attestix==0.4.0rc3` wheel — the cross-OS gate
+the rc.2 report owed) confirmed that 4 of the 5 rc.2 P0s held on Linux and
+the 0600 signing-key fix is enforced, but it surfaced **4 release blockers**
+that only became reachable once rc.3 fixed the install-time crashes that
+had masked them. rc.4 lands all 4. A clean Linux re-run of the same harness
+(target: 10/10 quickstarts exit 0, 0 BLOCK verdicts, DoC raises on every
+path) is the gate before promoting to stable 0.4.0.
+
+### Fixed
+
+- **P0 — `generate_declaration_of_conformity` now raises on ALL
+  prerequisite-failure branches (finishes the rc.3 P0 #4 fix).** rc.3 made
+  the method raise `InvalidComplianceProfileError` when the Annex V
+  *content* fields were missing, but it still returned `{"error": ...}`
+  (no `declaration_id`) on the **prerequisite** branches — no compliance
+  profile, and conformity assessment not completed — reproducing the exact
+  "move forward with `declaration_id=None`" footgun rc.3 claimed to have
+  eliminated. rc.4 adds `MissingCompliancePrerequisiteError` (a subclass of
+  `InvalidComplianceProfileError`, so the existing MCP-tool and REST-router
+  handlers surface it as a structured error / HTTP 422 unchanged) and
+  raises it on every early-return path: no profile, no completed
+  assessment, and the high-risk self-assessment-where-third-party-required
+  case. Each message names exactly which prerequisite is missing and the
+  method to call to satisfy it. No silent `{"error": ...}` survives at the
+  service layer for this method. Covered by new unit tests asserting it
+  *raises* (not returns an error dict) for the no-profile and
+  no-assessment paths.
+- **P0 — grc-consultant quickstart no longer crashes with
+  `KeyError: 'credential_id'`.** The published quickstart bundled the
+  declaration into a Verifiable Presentation via
+  `declaration["credential_id"]`, but the DoC return had no such key (it
+  issued the backing `EUAIActComplianceCredential` VC internally and then
+  discarded its id). rc.4 surfaces the issued VC's id on the declaration
+  return as `credential_id` (the honest shape — that VC is exactly what the
+  VP step needs), and fixes the quickstart's
+  `create_verifiable_presentation(...)` call to use the real keyword
+  arguments (`agent_id`, `credential_ids`, `audience_did`). The signed,
+  persisted Annex V declaration is unchanged — `credential_id` is added to
+  the in-memory return only, after signing, so declaration signatures stay
+  valid.
+- **P0 — enterprise-architect / mlops-engineer REST paths corrected to the
+  `/v1/` prefix.** The quickstarts POSTed to `/identities` and GET
+  `/audit/{id}`, but every FastAPI router mounts under `/v1` — the real
+  routes are `POST /v1/identities` and
+  `GET /v1/provenance/audit-trail/{agent_id}`. Both documented paths
+  returned HTTP 404 live. All REST paths in the quickstart docs (including
+  the mlops `curl` and the enterprise-architect endpoint-surface list) now
+  carry the `/v1/` prefix, verified against the router prefixes in
+  `attestix/api/routers/`.
+- **P1 — mlops-engineer requirements pin bumped off `0.4.0rc2`.** The
+  published `requirements-attestix.txt` snippet pinned `attestix==0.4.0rc2`;
+  bumped to `0.4.0rc4`. Stale `v0.4.0-rc.2` / `v0.4.0-rc.3` version
+  references across the quickstart docs (devtools-skeptic, index, indie-dev,
+  fintech-compliance) were bumped to `v0.4.0-rc.4` for consistency.
+
 ## [0.4.0-rc.3] - 2026-05-28
 
 Honest follow-up to rc.2. The isolated 10-persona RC validation (run with

--- a/attestix/__init__.py
+++ b/attestix/__init__.py
@@ -29,7 +29,7 @@ Modules:
     - attestix.errors: Centralized error categories and structured logging
 """
 
-__version__ = "0.4.0rc3"
+__version__ = "0.4.0rc4"
 
 # Re-export submodules for convenient access
 from attestix import services

--- a/attestix/services/compliance_service.py
+++ b/attestix/services/compliance_service.py
@@ -36,6 +36,27 @@ class InvalidComplianceProfileError(ValueError):
         self.missing_fields = list(missing_fields or [])
 
 
+class MissingCompliancePrerequisiteError(InvalidComplianceProfileError):
+    """Raised when a prerequisite for generating an Annex V declaration of
+    conformity is not satisfied (no compliance profile exists for the agent,
+    or no completed conformity assessment has been recorded).
+
+    v0.4.0-rc.4 (P0 #4 finish of the Linux RC validation): the rc.3 fix made
+    ``generate_declaration_of_conformity`` raise on the missing Annex V
+    *content* fields path, but the **prerequisite** branches (no profile / no
+    completed assessment) still returned ``{"error": "..."}`` (no
+    ``declaration_id``), reproducing the exact "move forward with
+    declaration_id=None" footgun the rc.3 docs claimed to have eliminated.
+    Those branches now raise this exception so callers fail loudly on every
+    path.
+
+    Subclasses :class:`InvalidComplianceProfileError` so the existing MCP tool
+    and REST router handlers (which already catch
+    ``InvalidComplianceProfileError``) surface it as a structured 422 / error
+    JSON without further changes.
+    """
+
+
 VALID_RISK_CATEGORIES = {"minimal", "limited", "high", "unacceptable"}
 VALID_ASSESSMENT_TYPES = {"self", "third_party"}
 VALID_ASSESSMENT_RESULTS = {"pass", "conditional", "fail"}
@@ -479,14 +500,26 @@ class ComplianceService:
         try:
             profile = self.get_compliance_profile(agent_id)
             if not profile:
-                return {"error": f"No compliance profile found for {agent_id}"}
+                # v0.4.0-rc.4 (P0 #4 finish): raise on the no-profile
+                # prerequisite branch instead of returning an error dict, so
+                # callers cannot move forward with declaration_id=None.
+                raise MissingCompliancePrerequisiteError(
+                    f"Cannot generate declaration: no compliance profile exists "
+                    f"for agent {agent_id}; create one with "
+                    f"create_compliance_profile() before generating a "
+                    f"declaration."
+                )
 
             # Check prerequisites
             if not profile["conformity"]["assessment_completed"]:
-                return {
-                    "error": "Cannot generate declaration: conformity assessment not completed or not passed. "
-                    "Use record_conformity_assessment first."
-                }
+                # v0.4.0-rc.4 (P0 #4 finish): raise on the assessment-missing
+                # prerequisite branch instead of returning an error dict.
+                raise MissingCompliancePrerequisiteError(
+                    f"Cannot generate declaration: no completed conformity "
+                    f"assessment for agent {agent_id}; record one with "
+                    f"record_conformity_assessment() (result 'pass' or "
+                    f"'conditional') before generating a declaration."
+                )
 
             # Validate required Annex V fields
             missing_fields = []
@@ -513,12 +546,17 @@ class ComplianceService:
                             profile.get("annex_iii_exception"),
                         )
                         if required:
-                            return {
-                                "error": (
-                                    f"Cannot issue declaration: {reason} "
-                                    f"Current assessment is self-assessment."
-                                )
-                            }
+                            # v0.4.0-rc.4 (P0 #4 finish): raise on the
+                            # wrong-assessment-type prerequisite branch too so
+                            # no early-return error dict survives in this method.
+                            raise MissingCompliancePrerequisiteError(
+                                f"Cannot issue declaration: {reason} Current "
+                                f"assessment for agent {agent_id} is a "
+                                f"self-assessment; record a third_party "
+                                f"conformity assessment with a notified body "
+                                f"via record_conformity_assessment() before "
+                                f"generating a declaration."
+                            )
             if missing_fields:
                 # v0.4.0-rc.3 (P0 #4): raise instead of returning an error dict
                 # so callers cannot silently move forward with declaration_id=None.
@@ -618,8 +656,14 @@ class ComplianceService:
 
             save_compliance(data)
 
-            # Issue a Verifiable Credential for this declaration
-            self.credential_svc.issue_credential(
+            # Issue a Verifiable Credential for this declaration.
+            # v0.4.0-rc.4: surface the issued VC's id on the declaration return
+            # as ``credential_id`` so callers can bundle it into a Verifiable
+            # Presentation directly (the grc-consultant quickstart's VP step
+            # needs exactly this id). Previously the VC was issued but its id
+            # was discarded, so the declaration dict had no credential id to
+            # reference.
+            issued_credential = self.credential_svc.issue_credential(
                 subject_id=agent_id,
                 credential_type="EUAIActComplianceCredential",
                 issuer_name=profile["provider"]["name"],
@@ -632,6 +676,8 @@ class ComplianceService:
                 },
                 expiry_days=365,
             )
+            if isinstance(issued_credential, dict) and issued_credential.get("id"):
+                declaration["credential_id"] = issued_credential["id"]
 
             safe_emit(
                 self._emitter,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attestix"
-version = "0.4.0rc3"
+version = "0.4.0rc4"
 description = "Attestix - Attestation Infrastructure for AI Agents. DID-based agent identity, W3C Verifiable Credentials, EU AI Act compliance, delegation chains, and reputation scoring. 47 MCP tools across 9 modules."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/unit/test_compliance.py
+++ b/tests/unit/test_compliance.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from attestix.services.compliance_service import InvalidComplianceProfileError
+from attestix.services.compliance_service import (
+    InvalidComplianceProfileError,
+    MissingCompliancePrerequisiteError,
+)
 
 
 class TestCreateComplianceProfile:
@@ -329,15 +332,40 @@ class TestDeclarationOfConformity:
         assert result["declaration_id"].startswith("decl:")
         assert "annex_v_fields" in result
 
-    def test_requires_assessment(self, compliance_service, sample_agent_id):
+    def test_requires_assessment_raises(self, compliance_service, sample_agent_id):
+        """v0.4.0-rc.4 (P0 #4 finish, Linux RC validation): the
+        assessment-missing prerequisite branch must RAISE
+        MissingCompliancePrerequisiteError, not return {"error": "..."}.
+        The rc.3 fix only covered the missing-content-fields path; this
+        prerequisite path still silently returned an error dict with no
+        declaration_id (the exact "move forward with declaration_id=None"
+        footgun). The message must name the missing prerequisite and the
+        method to call.
+        """
         compliance_service.create_compliance_profile(
             sample_agent_id, "limited", "Corp",
             intended_purpose="Testing",
             transparency_obligations="Disclose",
         )
-        result = compliance_service.generate_declaration_of_conformity(sample_agent_id)
-        assert "error" in result
-        assert "assessment" in result["error"].lower()
+        with pytest.raises(MissingCompliancePrerequisiteError) as exc:
+            compliance_service.generate_declaration_of_conformity(sample_agent_id)
+        msg = str(exc.value).lower()
+        assert "conformity assessment" in msg
+        assert "record_conformity_assessment" in msg
+        # Subclasses InvalidComplianceProfileError so existing handlers catch it.
+        assert isinstance(exc.value, InvalidComplianceProfileError)
+
+    def test_no_profile_raises(self, compliance_service, sample_agent_id):
+        """v0.4.0-rc.4 (P0 #4 finish): the no-profile prerequisite branch
+        must RAISE MissingCompliancePrerequisiteError naming the missing
+        prerequisite (no profile) and the method to call.
+        """
+        with pytest.raises(MissingCompliancePrerequisiteError) as exc:
+            compliance_service.generate_declaration_of_conformity("uait:does-not-exist")
+        msg = str(exc.value).lower()
+        assert "no compliance profile" in msg
+        assert "create_compliance_profile" in msg
+        assert isinstance(exc.value, InvalidComplianceProfileError)
 
     def test_missing_transparency_obligations_raises(self, compliance_service, sample_agent_id):
         """v0.4.0-rc.3 (P0 #4 of the rc.2 RC validation): missing required

--- a/website/content/docs/quickstart/devtools-skeptic.mdx
+++ b/website/content/docs/quickstart/devtools-skeptic.mdx
@@ -1,11 +1,11 @@
 ---
 title: DevTools / DX skeptic — Quickstart
-description: Does the package actually import? Yes, in v0.4.0-rc.2. Here's the smallest possible test you can run in 60 seconds to verify the DX claim before reading anything else.
+description: Does the package actually import? Yes, in v0.4.0-rc.4. Here's the smallest possible test you can run in 60 seconds to verify the DX claim before reading anything else.
 ---
 
 ## You're here because…
 
-You're a senior DX-minded developer and the funnel evaluation said the previous Attestix install required `sys.path.insert` to a cloned repo because `pip install attestix` dropped flat top-level packages (`services/`, `auth/`, `storage/`, …) into `site-packages`. That was the cheapest, loudest failure across the whole ICP review. v0.4.0-rc.2 fixes it. This page exists so you can prove that, end-to-end, in under a minute, without reading any other doc.
+You're a senior DX-minded developer and the funnel evaluation said the previous Attestix install required `sys.path.insert` to a cloned repo because `pip install attestix` dropped flat top-level packages (`services/`, `auth/`, `storage/`, …) into `site-packages`. That was the cheapest, loudest failure across the whole ICP review. v0.4.0-rc.4 fixes it. This page exists so you can prove that, end-to-end, in under a minute, without reading any other doc.
 
 ## 60-second install
 
@@ -65,7 +65,7 @@ If you see `canonical ok` and zero stderr, the import surface is clean. If you s
 
 ## Honest things you should know before sending this to your team
 
-- v0.4.0-rc.2 is a release candidate. The legacy flat top-level packages (`services/`, `auth/`, `storage/`, …) are still installed as deprecation shims and **will be removed in v0.5.0**.
+- v0.4.0-rc.4 is a release candidate. The legacy flat top-level packages (`services/`, `auth/`, `storage/`, …) are still installed as deprecation shims and **will be removed in v0.5.0**.
 - Single maintainer, ~15 GitHub stars, no third-party security audit. The package is functional but not yet enterprise-hardened — see the [enterprise architect quickstart](/docs/quickstart/enterprise-architect) for the explicit gap list.
 - The signing key lives in `.signing_key.json` in the working directory and is plaintext by default. Set `ATTESTIX_KEY_PASSPHRASE` to enable AES-256-GCM encryption at rest.
 

--- a/website/content/docs/quickstart/enterprise-architect.mdx
+++ b/website/content/docs/quickstart/enterprise-architect.mdx
@@ -35,7 +35,7 @@ import os, requests, uuid
 BASE = os.environ.get("ATTESTIX_URL", "http://localhost:8000")
 
 resp = requests.post(
-    f"{BASE}/identities",
+    f"{BASE}/v1/identities",
     json={
         "display_name": "platform-issued-agent",
         "source_protocol": "manual",
@@ -56,7 +56,7 @@ print(agent["agent_id"], agent["issuer"]["did"])
 
 # Subsequent reads scope to the same tenant.
 trail = requests.get(
-    f"{BASE}/audit/{agent['agent_id']}",
+    f"{BASE}/v1/provenance/audit-trail/{agent['agent_id']}",
     headers={"X-Tenant-Id": "tenant_a"},
 ).json()
 print(len(trail), "audit rows so far")
@@ -64,7 +64,7 @@ print(len(trail), "audit rows so far")
 
 ## What you just got
 
-- An HTTP service exposing the 44 REST endpoints (`/identities`, `/credentials`, `/compliance`, `/audit`, `/delegations`, …) — same surface as the 47 MCP tools.
+- An HTTP service exposing the 44 REST endpoints, all under a `/v1/` prefix (`/v1/identities`, `/v1/credentials`, `/v1/compliance`, `/v1/provenance/audit-trail/{id}`, `/v1/delegations`, …) — same surface as the 47 MCP tools.
 - An idempotency middleware: repeating the same `Idempotency-Key` returns the cached response, not a duplicate write.
 - A tenant context header (`X-Tenant-Id`) that is plumbed through every service and stamped onto audit events. Pair it with your existing OIDC / mTLS edge.
 

--- a/website/content/docs/quickstart/fintech-compliance.mdx
+++ b/website/content/docs/quickstart/fintech-compliance.mdx
@@ -5,7 +5,7 @@ description: Wire a trading or credit-scoring agent with hash-chained audit, sig
 
 ## You're here because…
 
-You're a compliance engineer on a fintech / trading-agent stack. The funnel evaluation flagged that fintech evaluators dropped at install because the legacy package needed a `sys.path` hack and because Base L2 anchoring is **testnet only** — not legally binding for trading audit yet. v0.4.0-rc.2 fixes the import problem (`pip install --pre attestix` gives you the canonical `attestix.*` namespace). The testnet caveat still applies and is called out below.
+You're a compliance engineer on a fintech / trading-agent stack. The funnel evaluation flagged that fintech evaluators dropped at install because the legacy package needed a `sys.path` hack and because Base L2 anchoring is **testnet only** — not legally binding for trading audit yet. v0.4.0-rc.4 fixes the import problem (`pip install --pre attestix` gives you the canonical `attestix.*` namespace). The testnet caveat still applies and is called out below.
 
 ## 60-second install
 
@@ -55,7 +55,8 @@ ComplianceService().create_compliance_profile(
     human_oversight_measures="Loan officer reviews every AI recommendation before approval.",
     # Article 50 transparency: required to issue an Annex V declaration.
     # Omitting this used to silently make generate_declaration_of_conformity
-    # return an error dict instead of raising; v0.4.0-rc.3 raises early.
+    # return an error dict instead of raising; v0.4.0-rc.4 raises early on
+    # every prerequisite and missing-field path.
     transparency_obligations="Borrowers are informed in writing that an AI system contributed to the credit decision per Article 50.",
     # Annex III Point 5: access to essential private services (credit) is
     # high-risk via Point 5. Without this the service defaults to requiring

--- a/website/content/docs/quickstart/grc-consultant.mdx
+++ b/website/content/docs/quickstart/grc-consultant.mdx
@@ -70,9 +70,9 @@ print(declaration["declaration_id"])  # signed Annex V document id
 
 ```python
 vp = CredentialService().create_verifiable_presentation(
-    holder_id=agent_id,
-    credentials=[declaration["credential_id"]],
-    verifier="did:web:eu.regulator",
+    agent_id=agent_id,
+    credential_ids=[declaration["credential_id"]],
+    audience_did="did:web:eu.regulator",
     challenge="ch_audit_2026",
 )
 ```

--- a/website/content/docs/quickstart/index.mdx
+++ b/website/content/docs/quickstart/index.mdx
@@ -5,7 +5,7 @@ description: Copy-paste to verifiable agents in 90 seconds. One page per ICP per
 
 # Quickstart
 
-Pick the page that matches your role. Every page is **90-second-readable** with a copy-paste path that runs against a clean `pip install --pre attestix` (v0.4.0-rc.2, canonical `attestix.*` namespace).
+Pick the page that matches your role. Every page is **90-second-readable** with a copy-paste path that runs against a clean `pip install --pre attestix` (v0.4.0-rc.4, canonical `attestix.*` namespace).
 
 The 10 pages below correspond to the 10 ICP personas surfaced in the [v0.4.0 funnel evaluation](https://github.com/VibeTensor/attestix/blob/main/CHANGELOG.md#040-rc2---2026-05-28). Each one targets the exact step at which that persona dropped off.
 

--- a/website/content/docs/quickstart/indie-dev.mdx
+++ b/website/content/docs/quickstart/indie-dev.mdx
@@ -5,7 +5,7 @@ description: For the solo founder shipping a LangChain RAG agent fast. Skip the 
 
 ## You're here because…
 
-You're a solo or small-team dev shipping a LangChain agent and you don't have time to hand-roll an audit trail before launch. The funnel evaluation flagged that the "5-minute promise" used to break at the import step — `from services.identity_service import …` only worked from a cloned repo, not from a clean `pip install`. v0.4.0-rc.2 ships the canonical `attestix.*` namespace, so the snippet below runs end-to-end from a fresh venv.
+You're a solo or small-team dev shipping a LangChain agent and you don't have time to hand-roll an audit trail before launch. The funnel evaluation flagged that the "5-minute promise" used to break at the import step — `from services.identity_service import …` only worked from a cloned repo, not from a clean `pip install`. v0.4.0-rc.4 ships the canonical `attestix.*` namespace, so the snippet below runs end-to-end from a fresh venv.
 
 ## 60-second install
 
@@ -13,7 +13,7 @@ You're a solo or small-team dev shipping a LangChain agent and you don't have ti
 pip install --pre 'attestix[langchain]'
 ```
 
-That installs v0.4.0-rc.2 plus the `langchain-core` extra. Drop the `--pre` once v0.4.0 GA ships.
+That installs v0.4.0-rc.4 plus the `langchain-core` extra. Drop the `--pre` once v0.4.0 GA ships.
 
 ## First 30 lines that actually do something
 

--- a/website/content/docs/quickstart/mlops-engineer.mdx
+++ b/website/content/docs/quickstart/mlops-engineer.mdx
@@ -5,14 +5,14 @@ description: Wire Attestix into a CI/CD pipeline so every model promotion produc
 
 ## You're here because…
 
-You're an MLOps engineer and the funnel evaluation flagged that your peers dropped at integration because the tool felt CLI-first / single-user — no idempotent declarative API, no Terraform / Ansible module, file-based state. This page accepts that gap and shows the realistic CI path today: a deterministic CLI plus the idempotency-aware REST surface for a CI runner. The pluggable storage backend and IaC modules are on the [roadmap](/docs/project/roadmap); what's below works against v0.4.0-rc.2 unchanged.
+You're an MLOps engineer and the funnel evaluation flagged that your peers dropped at integration because the tool felt CLI-first / single-user — no idempotent declarative API, no Terraform / Ansible module, file-based state. This page accepts that gap and shows the realistic CI path today: a deterministic CLI plus the idempotency-aware REST surface for a CI runner. The pluggable storage backend and IaC modules are on the [roadmap](/docs/project/roadmap); what's below works against v0.4.0-rc.4 unchanged.
 
 ## 60-second install
 
 Pin the version in `requirements-attestix.txt` so the CI run is reproducible:
 
 ```text
-attestix==0.4.0rc2
+attestix==0.4.0rc4
 ```
 
 Then in the CI step:
@@ -91,7 +91,7 @@ If you don't want to share the `.signing_key.json` between runners, run Attestix
 ```bash
 # Start the FastAPI REST surface (the MCP stdio server is `python -m attestix.main`).
 uvicorn attestix.api.main:app --host 127.0.0.1 --port 8501 &
-curl -sX POST http://localhost:8501/identities \
+curl -sX POST http://localhost:8501/v1/identities \
   -H "Idempotency-Key: gha-${GITHUB_RUN_ID}-promote" \
   -H "Content-Type: application/json" \
   -d '{"display_name":"'"$MODEL_NAME"'","source_protocol":"manual","capabilities":["'$MODEL_TASK'"],"issuer_name":"VibeTensor"}'


### PR DESCRIPTION
## Summary

Cuts `attestix==0.4.0rc4` with the 4 release blockers the **internal Linux RC validation report** caught (source-blind 10-persona harness inside WSL Ubuntu 24.04 / CPython 3.12, run against the published `attestix==0.4.0rc3` wheel — the cross-OS gate the rc.2 Windows-only run owed). That report confirmed 4 of 5 rc.2 P0s held on Linux and the `0600` signing-key fix is enforced, but 4 blockers only became reachable once rc.3 fixed the install-time crashes that had masked them.

These are validation findings, not GitHub issues — nothing auto-closed.

## The 4 blockers + per-blocker fix

### P0 — `generate_declaration_of_conformity` silent error dict on prerequisite branches (finishes rc.3 P0 #4)
rc.3 made the method **raise** `InvalidComplianceProfileError` when Annex V *content* fields were missing, but it still `return {"error": ...}` (no `declaration_id`) on the **prerequisite** branches: (a) no compliance profile, (b) conformity assessment not completed — the exact "move forward with `declaration_id=None`" footgun rc.3 claimed to have eliminated.

**Fix:** added `MissingCompliancePrerequisiteError` (subclass of `InvalidComplianceProfileError`, so the existing MCP-tool and REST-router handlers surface it as a structured error / HTTP 422 with no changes) and made the method **raise** on every early-return path — no profile, no completed assessment, and the high-risk self-assessment-where-third-party-required case. Each message names exactly which prerequisite is missing and the method to call. **No silent `{"error": ...}` survives at the service layer for this method.** The REST route maps the exception to HTTP 422; the MCP tool to a structured `error` JSON.

### P0 — grc-consultant quickstart `declaration["credential_id"]` KeyError
The DoC issued the backing `EUAIActComplianceCredential` VC internally but **discarded its id**, so the declaration dict had no `credential_id` key.

**Fix (code + doc):** surface the issued VC's id on the declaration return as `credential_id` — the honest shape, since that VC is exactly what the VP step bundles. It is added to the **in-memory return only, after signing**, so the signed/persisted Annex V declaration is byte-unchanged and signatures stay valid. The quickstart's `create_verifiable_presentation(...)` call was **also** wrong on three kwargs — fixed `holder_id`/`credentials`/`verifier` → real `agent_id`/`credential_ids`/`audience_did`.

### P0 — enterprise-architect / mlops REST paths 404
Quickstarts POSTed to `/identities` and GET `/audit/{id}`; every FastAPI router mounts under `/v1`.

**Fix (doc):** corrected to `POST /v1/identities` and `GET /v1/provenance/audit-trail/{agent_id}` (verified against the router prefixes in `attestix/api/routers/`). Updated the enterprise-architect endpoint-surface list and the mlops `curl` too.

### P1 — mlops requirements stale pin
`requirements-attestix.txt` snippet pinned `attestix==0.4.0rc2` → bumped to `0.4.0rc4`. Stale `v0.4.0-rc.2` / `v0.4.0-rc.3` version references across the quickstart docs (devtools-skeptic, index, indie-dev, fintech-compliance) bumped to `v0.4.0-rc.4` for consistency.

## Version + CHANGELOG
- `pyproject.toml` + `attestix/__init__.py`: `0.4.0rc3` → `0.4.0rc4` (version bumped nowhere else).
- `CHANGELOG.md`: new `[0.4.0-rc.4]` entry crediting the internal Linux RC validation report.

## Test / build evidence
- **pytest:** full suite **580 passed, 3 skipped**.
- New unit tests assert the DoC **raises** (not returns an error dict) for the no-profile path and the no-completed-assessment path, with each message naming the missing prerequisite; the pre-existing missing-content-field raise test is retained.
- **`next build`:** PASSES — compiled successfully, **81 static pages** generated and exported (the quickstart MDX edits are website content).

## Gate before stable 0.4.0
A clean **Linux re-validation** (10/10 quickstarts exit 0, 0 BLOCK verdicts, DoC raises on every path) is the gate before promoting `0.4.0rc4` → stable `0.4.0`. **Do not cut the GitHub Release from this PR.** Leaving open for manual merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved credential identifier handling issue in compliance workflows
  * Corrected REST API endpoint paths to use versioned `/v1/` prefix
  * Improved error messaging for missing compliance prerequisites

* **Documentation**
  * Updated all quickstart guides to version 0.4.0rc4

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VibeTensor/attestix/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->