### PR TITLE
release(0.4.0-rc.5): idempotency replays cached body (not receipt) + rc4 validation P2s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,83 @@ All notable changes to Attestix are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.0-rc.5] - 2026-05-30
+
+Narrow convergence on rc.4. The internal Linux RC validation
+(source-blind 10-persona harness inside WSL Ubuntu 24.04 / CPython 3.12
+against the published `attestix==0.4.0rc4` wheel) confirmed all 4 rc.3
+blockers stayed CLOSED and all 5 rc.2 P0s held on Linux, and surfaced one
+new **P1 DX/contract defect** (plus two P2s) reachable only once rc.4 fixed
+the `/v1/` REST paths. rc.5 lands the P1; both P2s are documented and
+deferred to v0.4.1 (neither is a security or data-integrity issue, and
+forcing either into the RC carries more regression risk than the defect it
+removes). A clean Linux re-run of the same harness
+(target: an idempotent retry returns the cached identity body — `agent_id`
+present — and 0 BLOCK verdicts) is the gate before promoting to stable 0.4.0.
+
+### Fixed
+
+- **P1 — REST idempotency replay now echoes the original cached response
+  body, not a receipt envelope.** A retried `POST /v1/identities` with the
+  same `Idempotency-Key` correctly created **no duplicate** (the dedup
+  guarantee was always intact — 3× same-key POST persisted exactly 1
+  identity), but the *replay body* was a middleware envelope —
+  `{"idempotent_replay": true, "stored_response": {"resource_id": null,
+  "response_hash": …}}` — instead of the original response. A CI client
+  retrying and reading `resp.json()["agent_id"]` got `None`, defeating the
+  purpose of idempotency on the retry path. rc.5 makes the middleware
+  persist the original HTTP response (status + body + content-type) and
+  replay it **verbatim** on a key hit, Stripe-style, so a retry is
+  indistinguishable from the first success (`agent_id` survives, status code
+  is preserved — e.g. `201` is replayed as `201`, not coerced to `200`).
+  Replay metadata moved to an `Idempotency-Replayed: true` **response
+  header** so clients can still detect a replay without the body shape
+  changing. The same-key/**different**-payload conflict (HTTP 409) and the
+  24h TTL are unchanged. The direct/MCP `run_idempotent` helper keeps the
+  FR-029 minimal receipt (it returns the live result on the first call and
+  never needs to re-serialize a body); only the REST boundary stores the
+  replayable body, which is the exact JSON the client already received.
+  Covered by new end-to-end tests against the live FastAPI app (retry
+  returns the same `agent_id`/status, N replays → exactly 1 identity,
+  different payload → 409).
+
+### Known issues (deferred to v0.4.1)
+
+- **P2 — a bare REST identity-create shows 0 rows on
+  `GET /v1/provenance/audit-trail/{id}`.** The service layer DOES emit an
+  `identity.create` event into the structured audit collection on every
+  create path (verified), but `get_audit_trail` reads only the legacy
+  Article-12 provenance chain (written by `log_action`), so a brand-new
+  identity with no logged actions returns `[]`. This is *arguably correct* —
+  a freshly created identity has no Article-12 provenance yet — but reads as
+  "provenance broken" to a first-time evaluator. Surfacing the
+  `audit.json::events` rows through `get_audit_trail` is the right fix, but
+  it changes that read API's contract for **every** consumer: it breaks the
+  contiguous hash-chain ordering the trail guarantees today and the
+  exact-row-count expectations several existing tests and consumers rely on.
+  That is a semantic change to a core read surface, not a one-line wiring
+  fix, so it is deferred to v0.4.1 (where the trail can be reshaped to merge
+  both chains in a single, ordering-stable, documented response). The
+  `identity.create` event is already recorded and counted by
+  `get_provenance` (rc.3 P0 #5); only the audit-trail *read* lags. Not a
+  data-integrity issue — the event exists.
+- **P2 — capability-escalation in `create_delegation` is refused via an
+  error-dict, not a raised exception.** The delegation control correctly and
+  securely blocks an over-broad sub-delegation (fails closed; an attenuated
+  subset succeeds), but returns `{"error": "Capability escalation denied: …"}`
+  rather than raising — inconsistent with the rc.4 direction of having
+  `generate_declaration_of_conformity` raise. This is intentionally **not**
+  changed in rc.5: the entire `create_delegation` method returns error-dicts
+  on every failure branch, and both the REST router and the MCP tool layer
+  depend on that dict shape (`isinstance(result, dict) and "error" in
+  result`). Converting one branch would be internally inconsistent; converting
+  the whole method touches every caller and risks destabilizing delegation
+  this late in the RC cycle. Tracked as a consistency item for v0.4.1. Not a
+  security issue — the escalation IS blocked.
+
+Credit: internal Linux RC validation
+(`paper/internal/v0.4.0rc4-linux-validation-2026-05-30.md`).
+
 ## [0.4.0-rc.4] - 2026-05-30
 
 Honest follow-up to rc.3. The internal Linux RC validation report

--- a/attestix/__init__.py
+++ b/attestix/__init__.py
@@ -29,7 +29,7 @@ Modules:
     - attestix.errors: Centralized error categories and structured logging
 """
 
-__version__ = "0.4.0rc4"
+__version__ = "0.4.0rc5"
 
 # Re-export submodules for convenient access
 from attestix import services

--- a/attestix/idempotency/middleware.py
+++ b/attestix/idempotency/middleware.py
@@ -49,13 +49,20 @@ def _build_middleware_class():
     except Exception:  # pragma: no cover - REST stack absent
         return None
 
+    #: Header set on a replayed response so a client CAN detect a retry was served
+    #: from the idempotency store WITHOUT the body shape changing (replay metadata
+    #: belongs in a header, not the body — v0.4.0-rc.5 P1 fix).
+    REPLAYED_HEADER = "Idempotency-Replayed"
+
     class IdempotencyMiddleware(BaseHTTPMiddleware):
         """Honor ``Idempotency-Key`` on write requests (opt-in; see module docs).
 
         On a write request carrying the header:
 
-        - same key + same request fingerprint within TTL → returns the stored
-          minimal response without re-dispatching (FR-019);
+        - same key + same request fingerprint within TTL → replays the original
+          cached response (status + body) verbatim without re-dispatching, with an
+          ``Idempotency-Replayed: true`` header (FR-019; v0.4.0-rc.5 — previously a
+          ``{"idempotent_replay": …}`` receipt envelope that dropped the body);
         - same key + different fingerprint → ``409`` conflict (FR-020);
         - no header → request proceeds untouched (FR-022, v0.3.0 parity).
 
@@ -98,10 +105,21 @@ def _build_middleware_class():
                         },
                     )
                 if existing.get("status") == "completed":
-                    return JSONResponse(
-                        status_code=200,
-                        content={"idempotent_replay": True,
-                                 "stored_response": existing.get("stored_response")},
+                    # v0.4.0-rc.5 P1: replay the ORIGINAL cached response body
+                    # verbatim (same status, same JSON the first call returned —
+                    # including agent_id), so a retry is indistinguishable from the
+                    # first success. Replay metadata goes in a header, never the
+                    # body (previously this returned a receipt envelope that lost
+                    # the agent_id, breaking `resp.json()["agent_id"]` on retry).
+                    stored = existing.get("stored_response") or {}
+                    replay_status = stored.get("status", 200)
+                    replay_body = stored.get("body", "")
+                    replay_media = stored.get("media_type") or "application/json"
+                    return Response(
+                        content=replay_body,
+                        status_code=replay_status,
+                        media_type=replay_media,
+                        headers={REPLAYED_HEADER: "true"},
                     )
                 return JSONResponse(
                     status_code=409,
@@ -109,7 +127,7 @@ def _build_middleware_class():
                              "already in progress."},
                 )
 
-            # First writer: reserve, dispatch, record minimal representation.
+            # First writer: reserve, dispatch, record the replayable response.
             self._store.put(
                 {
                     "key": key,
@@ -130,7 +148,18 @@ def _build_middleware_class():
 
             response = await call_next(request)
 
-            from attestix.idempotency.store import minimal_stored_response
+            # Buffer the response body so it can be both persisted (for verbatim
+            # replay) and returned to this first caller. call_next yields a
+            # streaming response; we drain its body iterator once, then rebuild a
+            # concrete Response with the same status/headers/media-type.
+            from attestix.idempotency.store import replayable_stored_response
+
+            body_chunks = [chunk async for chunk in response.body_iterator]
+            response_body = b"".join(
+                chunk if isinstance(chunk, bytes) else chunk.encode("utf-8")
+                for chunk in body_chunks
+            )
+            media_type = response.media_type or response.headers.get("content-type")
 
             reserved = self._store.get(key, tenant_id=tenant_id)
             created_at = reserved["created_at"] if reserved else _now_iso()
@@ -140,16 +169,32 @@ def _build_middleware_class():
                     "key": key,
                     "tenant_id": tenant_id,
                     "request_fingerprint": fingerprint,
-                    "stored_response": minimal_stored_response(
-                        {"status_code": response.status_code},
-                        status=response.status_code,
+                    "stored_response": replayable_stored_response(
+                        status_code=response.status_code,
+                        body=response_body,
+                        media_type=media_type,
                     ),
                     "status": "completed",
                     "created_at": created_at,
                 },
                 tenant_id=tenant_id,
             )
-            return response
+
+            # Rebuild a concrete response carrying the buffered body. Copy the
+            # original headers but drop content-length (Starlette recomputes it for
+            # the new body) so the first call's response is byte-identical to what
+            # the handler produced.
+            rebuilt_headers = {
+                k: v
+                for k, v in response.headers.items()
+                if k.lower() != "content-length"
+            }
+            return Response(
+                content=response_body,
+                status_code=response.status_code,
+                headers=rebuilt_headers,
+                media_type=response.media_type,
+            )
 
     return IdempotencyMiddleware
 

--- a/attestix/idempotency/store.py
+++ b/attestix/idempotency/store.py
@@ -100,11 +100,49 @@ def minimal_stored_response(
     response body (which may carry a signed VC / identity data). The hash lets a
     replay confirm it is returning the same logical result without keeping a second
     unencrypted copy of sensitive material for 24h.
+
+    Use this for *direct/MCP* callers (:func:`run_idempotent`), which return the
+    live result object on the first call and only need the minimal receipt to prove
+    a replay is the same logical result. The REST boundary, by contrast, must echo
+    the original HTTP body verbatim on a retry (a client that retries cannot re-read
+    the first call's in-memory result), so it uses
+    :func:`replayable_stored_response`.
     """
     return {
         "status": status,
         "resource_id": resource_id,
         "response_hash": response_hash(response),
+    }
+
+
+def replayable_stored_response(
+    *,
+    status_code: int,
+    body: bytes,
+    media_type: Optional[str] = None,
+) -> dict:
+    """Build the REST replay representation: the original HTTP response, verbatim.
+
+    Unlike :func:`minimal_stored_response` (a receipt), this persists the original
+    status code, body bytes, and content type so a retry with the same
+    ``Idempotency-Key`` is *indistinguishable* from the first success — the client's
+    ``resp.json()["agent_id"]`` works on the retry (v0.4.0-rc.5 P1 fix; previously
+    the replay returned a ``{"idempotent_replay": …}`` receipt envelope and the
+    ``agent_id`` was lost).
+
+    Sensitive-data note (FR-029): the body is the *exact same JSON the client just
+    received over the wire on the first call* — no new secret is exposed by storing
+    it that the client did not already hold. ``response_hash`` is retained so the
+    integrity check still holds. Persisting the raw private signing key is still
+    avoided because the REST response itself never contains it (signatures are
+    public).
+    """
+    text = body.decode("utf-8", "replace")
+    return {
+        "status": status_code,
+        "media_type": media_type,
+        "body": text,
+        "response_hash": response_hash({"status": status_code, "body": text}),
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attestix"
-version = "0.4.0rc4"
+version = "0.4.0rc5"
 description = "Attestix - Attestation Infrastructure for AI Agents. DID-based agent identity, W3C Verifiable Credentials, EU AI Act compliance, delegation chains, and reputation scoring. 47 MCP tools across 9 modules."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/integration/test_idempotency_middleware.py
+++ b/tests/integration/test_idempotency_middleware.py
@@ -16,6 +16,8 @@ what ``api/main.py`` mounts, so these tests cover the wired REST boundary:
 - keys are scoped per tenant via ``X-Attestix-Tenant`` (FR-023).
 """
 
+import json
+
 import pytest
 
 from attestix.idempotency.middleware import IDEMPOTENCY_HEADER, IdempotencyMiddleware
@@ -93,11 +95,20 @@ def test_same_key_same_payload_dedupes():
     assert r1.json() == {"created": 1}
     assert calls["create"] == 1
 
-    # Same key + same body within TTL: the handler must NOT run again.
+    # Same key + same body within TTL: the handler must NOT run again, and the
+    # replay must echo the ORIGINAL response body verbatim (same status, same JSON
+    # — v0.4.0-rc.5 P1: NOT a {"idempotent_replay": …} receipt envelope).
     r2 = client.post("/create", headers=headers, content=b'{"x":1}')
     assert calls["create"] == 1  # deduped (no duplicate side effect)
-    assert r2.status_code == 200
-    assert r2.json().get("idempotent_replay") is True
+    assert r2.status_code == r1.status_code
+    assert r2.json() == r1.json() == {"created": 1}
+    # No receipt envelope leaks into the body.
+    assert "idempotent_replay" not in r2.json()
+    assert "stored_response" not in r2.json()
+    # Replay metadata is in a header, not the body.
+    assert r2.headers.get("Idempotency-Replayed") == "true"
+    # The first response is NOT marked as a replay.
+    assert r1.headers.get("Idempotency-Replayed") is None
 
 
 # --- Same key + different payload → 409 (FR-020) --------------------------
@@ -115,10 +126,10 @@ def test_same_key_different_payload_conflicts():
     assert calls["create"] == 1
 
 
-# --- FR-029 minimal stored representation ---------------------------------
+# --- REST replay stores the verbatim body (v0.4.0-rc.5 P1) ----------------
 
 
-def test_stored_record_is_minimal():
+def test_stored_record_holds_replayable_body():
     app, _, store = _build_app()
     client = TestClient(app)
     client.post("/create", headers={IDEMPOTENCY_HEADER: "k1"}, content=b'{"x":1}')
@@ -127,8 +138,36 @@ def test_stored_record_is_minimal():
     assert rec is not None
     assert rec["status"] == "completed"
     stored = rec["stored_response"]
-    # Only the minimal triplet is persisted — never the raw response body.
-    assert set(stored) == {"status", "resource_id", "response_hash"}
+    # The REST boundary persists the original status + body + media-type so a
+    # retry can echo the response verbatim, plus the integrity hash (FR-029 hash
+    # retained; the body is the same JSON the client already received).
+    assert set(stored) == {"status", "media_type", "body", "response_hash"}
+    assert stored["status"] == 200
+    assert json.loads(stored["body"]) == {"created": 1}
+    assert stored["response_hash"]
+
+
+def test_replay_echoes_original_status_code():
+    """A non-2xx status (e.g. 201) is replayed verbatim, not coerced to 200."""
+    calls = {"n": 0}
+
+    async def create_201(request):
+        calls["n"] += 1
+        return JSONResponse({"id": f"res-{calls['n']}"}, status_code=201)
+
+    app = Starlette(routes=[Route("/create201", create_201, methods=["POST"])])
+    store = RepositoryIdempotencyStore(repository=MemoryRepository())
+    app.add_middleware(IdempotencyMiddleware, store=store)
+    client = TestClient(app)
+
+    headers = {IDEMPOTENCY_HEADER: "k201"}
+    r1 = client.post("/create201", headers=headers, content=b'{"x":1}')
+    r2 = client.post("/create201", headers=headers, content=b'{"x":1}')
+    assert r1.status_code == 201
+    assert r2.status_code == 201  # replayed verbatim, not 200
+    assert r2.json() == r1.json() == {"id": "res-1"}  # same resource id on retry
+    assert calls["n"] == 1  # handler ran exactly once
+    assert r2.headers.get("Idempotency-Replayed") == "true"
 
 
 # --- Per-tenant scoping (FR-023) ------------------------------------------

--- a/tests/integration/test_idempotency_rest_replay.py
+++ b/tests/integration/test_idempotency_rest_replay.py
@@ -1,0 +1,101 @@
+"""End-to-end REST idempotency-replay tests against the live FastAPI app.
+
+Regression guard for the v0.4.0-rc.5 P1 (rc4 Linux 10-persona validation,
+``paper/internal/v0.4.0rc4-linux-validation-2026-05-30.md``):
+
+A retried ``POST /v1/identities`` with the same ``Idempotency-Key`` used to return
+a receipt envelope — ``{"idempotent_replay": true, "stored_response": {...,
+"resource_id": null}}`` — so a CI client doing ``resp.json()["agent_id"]`` on a
+retry got ``None``. The fix makes the replay echo the ORIGINAL cached response body
+verbatim (same status, same JSON including ``agent_id``), with replay metadata moved
+to an ``Idempotency-Replayed`` header.
+
+These tests exercise the real ``attestix.api.main.app`` (the auto-mounted
+``IdempotencyMiddleware``), so they cover the wired boundary the validation hit. The
+``tmp_attestix`` autouse fixture isolates all storage to a temp dir.
+"""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    # Import inside the fixture so the autouse tmp_attestix path patching is in
+    # effect before the app's services are first constructed.
+    from attestix.api.main import app
+
+    return TestClient(app)
+
+
+def _create_payload(name="Replay Agent"):
+    return {"display_name": name, "source_protocol": "api_key"}
+
+
+def test_retry_returns_same_body_with_agent_id(client):
+    """The headline fix: retry returns the SAME body, not a receipt envelope."""
+    headers = {"Idempotency-Key": "rc5-key-1"}
+
+    r1 = client.post("/v1/identities", json=_create_payload(), headers=headers)
+    assert r1.status_code == 201
+    first_body = r1.json()
+    agent_id = first_body["agent_id"]
+    assert agent_id  # non-empty
+
+    r2 = client.post("/v1/identities", json=_create_payload(), headers=headers)
+    # Same status, same body (incl. agent_id) — indistinguishable from the first.
+    assert r2.status_code == 201
+    assert r2.json() == first_body
+    assert r2.json()["agent_id"] == agent_id
+    # No receipt envelope leaks into the body.
+    assert "idempotent_replay" not in r2.json()
+    assert "stored_response" not in r2.json()
+    # Replay metadata is exposed via a header, not the body.
+    assert r2.headers.get("Idempotency-Replayed") == "true"
+    assert r1.headers.get("Idempotency-Replayed") is None
+
+
+def test_exactly_one_identity_after_n_replays(client):
+    """The dedup guarantee still holds: N same-key POSTs → exactly 1 identity."""
+    headers = {"Idempotency-Key": "rc5-key-dedup"}
+
+    bodies = [
+        client.post("/v1/identities", json=_create_payload(), headers=headers).json()
+        for _ in range(3)
+    ]
+    # All three replays returned the identical identity.
+    assert bodies[0] == bodies[1] == bodies[2]
+    agent_id = bodies[0]["agent_id"]
+
+    # Only one identity persisted (no duplicate writes).
+    listed = client.get("/v1/identities").json()
+    matching = [a for a in listed if a["agent_id"] == agent_id]
+    assert len(matching) == 1
+    # And the create endpoint never minted a second agent under this key.
+    assert sum(1 for b in bodies if b["agent_id"] == agent_id) == 3
+
+
+def test_same_key_different_payload_conflicts(client):
+    """Conflict behavior preserved: same key + different body → 409 (not a replay)."""
+    headers = {"Idempotency-Key": "rc5-key-conflict"}
+
+    r1 = client.post("/v1/identities", json=_create_payload("Agent A"), headers=headers)
+    assert r1.status_code == 201
+
+    r2 = client.post("/v1/identities", json=_create_payload("Agent B"), headers=headers)
+    assert r2.status_code == 409
+    assert r2.headers.get("Idempotency-Replayed") is None
+
+
+def test_different_keys_create_distinct_identities(client):
+    """A different key is a fresh write (dedup is keyed correctly)."""
+    r1 = client.post(
+        "/v1/identities", json=_create_payload(), headers={"Idempotency-Key": "rc5-a"}
+    )
+    r2 = client.post(
+        "/v1/identities", json=_create_payload(), headers={"Idempotency-Key": "rc5-b"}
+    )
+    assert r1.status_code == r2.status_code == 201
+    assert r1.json()["agent_id"] != r2.json()["agent_id"]

--- a/website/content/docs/quickstart/devtools-skeptic.mdx
+++ b/website/content/docs/quickstart/devtools-skeptic.mdx
@@ -1,11 +1,11 @@
 ---
 title: DevTools / DX skeptic — Quickstart
-description: Does the package actually import? Yes, in v0.4.0-rc.4. Here's the smallest possible test you can run in 60 seconds to verify the DX claim before reading anything else.
+description: Does the package actually import? Yes, in v0.4.0-rc.5. Here's the smallest possible test you can run in 60 seconds to verify the DX claim before reading anything else.
 ---
 
 ## You're here because…
 
-You're a senior DX-minded developer and the funnel evaluation said the previous Attestix install required `sys.path.insert` to a cloned repo because `pip install attestix` dropped flat top-level packages (`services/`, `auth/`, `storage/`, …) into `site-packages`. That was the cheapest, loudest failure across the whole ICP review. v0.4.0-rc.4 fixes it. This page exists so you can prove that, end-to-end, in under a minute, without reading any other doc.
+You're a senior DX-minded developer and the funnel evaluation said the previous Attestix install required `sys.path.insert` to a cloned repo because `pip install attestix` dropped flat top-level packages (`services/`, `auth/`, `storage/`, …) into `site-packages`. That was the cheapest, loudest failure across the whole ICP review. v0.4.0-rc.5 fixes it. This page exists so you can prove that, end-to-end, in under a minute, without reading any other doc.
 
 ## 60-second install
 
@@ -65,7 +65,7 @@ If you see `canonical ok` and zero stderr, the import surface is clean. If you s
 
 ## Honest things you should know before sending this to your team
 
-- v0.4.0-rc.4 is a release candidate. The legacy flat top-level packages (`services/`, `auth/`, `storage/`, …) are still installed as deprecation shims and **will be removed in v0.5.0**.
+- v0.4.0-rc.5 is a release candidate. The legacy flat top-level packages (`services/`, `auth/`, `storage/`, …) are still installed as deprecation shims and **will be removed in v0.5.0**.
 - Single maintainer, ~15 GitHub stars, no third-party security audit. The package is functional but not yet enterprise-hardened — see the [enterprise architect quickstart](/docs/quickstart/enterprise-architect) for the explicit gap list.
 - The signing key lives in `.signing_key.json` in the working directory and is plaintext by default. Set `ATTESTIX_KEY_PASSPHRASE` to enable AES-256-GCM encryption at rest.
 

--- a/website/content/docs/quickstart/fintech-compliance.mdx
+++ b/website/content/docs/quickstart/fintech-compliance.mdx
@@ -5,7 +5,7 @@ description: Wire a trading or credit-scoring agent with hash-chained audit, sig
 
 ## You're here because…
 
-You're a compliance engineer on a fintech / trading-agent stack. The funnel evaluation flagged that fintech evaluators dropped at install because the legacy package needed a `sys.path` hack and because Base L2 anchoring is **testnet only** — not legally binding for trading audit yet. v0.4.0-rc.4 fixes the import problem (`pip install --pre attestix` gives you the canonical `attestix.*` namespace). The testnet caveat still applies and is called out below.
+You're a compliance engineer on a fintech / trading-agent stack. The funnel evaluation flagged that fintech evaluators dropped at install because the legacy package needed a `sys.path` hack and because Base L2 anchoring is **testnet only** — not legally binding for trading audit yet. v0.4.0-rc.5 fixes the import problem (`pip install --pre attestix` gives you the canonical `attestix.*` namespace). The testnet caveat still applies and is called out below.
 
 ## 60-second install
 
@@ -55,7 +55,7 @@ ComplianceService().create_compliance_profile(
     human_oversight_measures="Loan officer reviews every AI recommendation before approval.",
     # Article 50 transparency: required to issue an Annex V declaration.
     # Omitting this used to silently make generate_declaration_of_conformity
-    # return an error dict instead of raising; v0.4.0-rc.4 raises early on
+    # return an error dict instead of raising; v0.4.0-rc.5 raises early on
     # every prerequisite and missing-field path.
     transparency_obligations="Borrowers are informed in writing that an AI system contributed to the credit decision per Article 50.",
     # Annex III Point 5: access to essential private services (credit) is

--- a/website/content/docs/quickstart/index.mdx
+++ b/website/content/docs/quickstart/index.mdx
@@ -5,7 +5,7 @@ description: Copy-paste to verifiable agents in 90 seconds. One page per ICP per
 
 # Quickstart
 
-Pick the page that matches your role. Every page is **90-second-readable** with a copy-paste path that runs against a clean `pip install --pre attestix` (v0.4.0-rc.4, canonical `attestix.*` namespace).
+Pick the page that matches your role. Every page is **90-second-readable** with a copy-paste path that runs against a clean `pip install --pre attestix` (v0.4.0-rc.5, canonical `attestix.*` namespace).
 
 The 10 pages below correspond to the 10 ICP personas surfaced in the [v0.4.0 funnel evaluation](https://github.com/VibeTensor/attestix/blob/main/CHANGELOG.md#040-rc2---2026-05-28). Each one targets the exact step at which that persona dropped off.
 

--- a/website/content/docs/quickstart/indie-dev.mdx
+++ b/website/content/docs/quickstart/indie-dev.mdx
@@ -5,7 +5,7 @@ description: For the solo founder shipping a LangChain RAG agent fast. Skip the 
 
 ## You're here because…
 
-You're a solo or small-team dev shipping a LangChain agent and you don't have time to hand-roll an audit trail before launch. The funnel evaluation flagged that the "5-minute promise" used to break at the import step — `from services.identity_service import …` only worked from a cloned repo, not from a clean `pip install`. v0.4.0-rc.4 ships the canonical `attestix.*` namespace, so the snippet below runs end-to-end from a fresh venv.
+You're a solo or small-team dev shipping a LangChain agent and you don't have time to hand-roll an audit trail before launch. The funnel evaluation flagged that the "5-minute promise" used to break at the import step — `from services.identity_service import …` only worked from a cloned repo, not from a clean `pip install`. v0.4.0-rc.5 ships the canonical `attestix.*` namespace, so the snippet below runs end-to-end from a fresh venv.
 
 ## 60-second install
 
@@ -13,7 +13,7 @@ You're a solo or small-team dev shipping a LangChain agent and you don't have ti
 pip install --pre 'attestix[langchain]'
 ```
 
-That installs v0.4.0-rc.4 plus the `langchain-core` extra. Drop the `--pre` once v0.4.0 GA ships.
+That installs v0.4.0-rc.5 plus the `langchain-core` extra. Drop the `--pre` once v0.4.0 GA ships.
 
 ## First 30 lines that actually do something
 

--- a/website/content/docs/quickstart/mlops-engineer.mdx
+++ b/website/content/docs/quickstart/mlops-engineer.mdx
@@ -5,14 +5,14 @@ description: Wire Attestix into a CI/CD pipeline so every model promotion produc
 
 ## You're here because…
 
-You're an MLOps engineer and the funnel evaluation flagged that your peers dropped at integration because the tool felt CLI-first / single-user — no idempotent declarative API, no Terraform / Ansible module, file-based state. This page accepts that gap and shows the realistic CI path today: a deterministic CLI plus the idempotency-aware REST surface for a CI runner. The pluggable storage backend and IaC modules are on the [roadmap](/docs/project/roadmap); what's below works against v0.4.0-rc.4 unchanged.
+You're an MLOps engineer and the funnel evaluation flagged that your peers dropped at integration because the tool felt CLI-first / single-user — no idempotent declarative API, no Terraform / Ansible module, file-based state. This page accepts that gap and shows the realistic CI path today: a deterministic CLI plus the idempotency-aware REST surface for a CI runner. The pluggable storage backend and IaC modules are on the [roadmap](/docs/project/roadmap); what's below works against v0.4.0-rc.5 unchanged.
 
 ## 60-second install
 
 Pin the version in `requirements-attestix.txt` so the CI run is reproducible:
 
 ```text
-attestix==0.4.0rc4
+attestix==0.4.0rc5
 ```
 
 Then in the CI step:


### PR DESCRIPTION
## Summary

Narrow convergence on rc.4. The internal Linux 10-persona RC validation (`paper/internal/v0.4.0rc4-linux-validation-2026-05-30.md`) confirmed **all 4 rc.3 blockers stayed CLOSED** and **all 5 rc.2 P0s held** on Linux, and surfaced **one new P1 DX/contract defect** (plus two P2s) reachable only once rc.4 fixed the `/v1/` REST paths. rc.5 lands the **P1**; both **P2s are documented and deferred to v0.4.1** (neither is a security or data-integrity issue, and forcing either into the RC carries more regression risk than the defect it removes).

## P1 (fixed) — idempotency replay returns the cached body, not a receipt

**Before:** a retried `POST /v1/identities` with the same `Idempotency-Key` returned a middleware envelope:

```json
{"idempotent_replay": true, "stored_response": {"status": 201, "resource_id": null, "response_hash": "…"}}
```

so a CI client retrying and reading `resp.json()["agent_id"]` got `None`. The dedup guarantee was **always intact** (3× same-key POST → exactly **1** identity); only the *replay body* was wrong.

**After:** the middleware (`attestix/idempotency/middleware.py`) now persists the original HTTP response (status + body + content-type) via a new `replayable_stored_response()` helper (`attestix/idempotency/store.py`) and **replays it verbatim** on a key hit — Stripe-style, so a retry is indistinguishable from the first success (`agent_id` survives, `201` replays as `201` not coerced to `200`).

- **Replay metadata moved to a response header** — `Idempotency-Replayed: true` — so clients can still detect a replay **without the body shape changing** (the right place for replay metadata).
- **Preserved:** the dedup guarantee (still exactly 1 resource), the same-key/**different**-payload `409` conflict, and the 24h TTL.
- The direct/MCP `run_idempotent` helper keeps the FR-029 minimal receipt (it returns the live result on the first call and never re-serializes a body); **only the REST boundary** stores the replayable body — which is the exact JSON the client already received over the wire, so no new secret is exposed.

## P2s (deferred to v0.4.1 — documented, not fixed)

1. **Bare REST identity-create shows 0 audit-trail rows.** The `identity.create` event **is** emitted to the structured audit collection on every create path (verified), but `get_audit_trail` reads only the legacy Article-12 provenance chain, so a brand-new identity with no logged actions returns `[]`. *Arguably correct* (no Article-12 provenance yet), but reads as "broken." Surfacing the `audit.json::events` rows through `get_audit_trail` is the right fix — but it **changes that read API's contract for every consumer** (breaks the contiguous hash-chain ordering and exact-row-count expectations several existing tests/consumers rely on). That is a semantic change to a core read surface, **not a one-line wiring fix**, so it is deferred to v0.4.1. `get_provenance` already counts the event (rc.3 P0 #5). Not a data-integrity issue — the event exists.

2. **Capability-escalation in `create_delegation` is refused via an error-dict, not a raise.** Secure (fails closed; an attenuated subset succeeds), but the **whole** `create_delegation` method returns error-dicts on every failure branch, and **both** the REST router (`isinstance(result, dict) and "error" in result`) and the MCP tool layer depend on that shape. Converting one branch is inconsistent; converting the method touches every caller and risks destabilizing delegation this late in the RC. Tracked for v0.4.1. Not a security issue — the escalation IS blocked.

## Version + docs

- `0.4.0rc4 → 0.4.0rc5` in `pyproject.toml` + `attestix/__init__.py` + `CHANGELOG.md`.
- 5 quickstart docs bumped rc4 → rc5 (the mlops-engineer install **pin** `attestix==0.4.0rc5` + prose mentions). The enterprise-architect quickstart's idempotency promise ("repeating the same `Idempotency-Key` returns the cached response") is now literally true.

## Test + build evidence

- **`pytest -q`: 585 passed, 3 skipped, 0 failed** (~48 s).
- New `tests/integration/test_idempotency_rest_replay.py` — end-to-end against the live FastAPI app: retry returns the **same** `agent_id` + status (not a receipt), `Idempotency-Replayed: true` header present, N replays → exactly 1 identity, different payload → `409`, distinct keys → distinct identities. Existing `test_idempotency_middleware.py` updated to the new replay contract (verbatim body, `201` replayed verbatim).
- Docs touched → `npx next build` (static export) **passes**; built `out/docs/quickstart/mlops-engineer.txt` carries `0.4.0rc5`, zero stale `rc4`. **Verify Cloudflare green on this PR before merge.**

## Gate

A **clean Linux re-validation** of the same 10-persona harness is the gate before promoting to stable 0.4.0 (target: enterprise-architect retry returns the cached identity body with `agent_id`, 0 BLOCK verdicts).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.4.0-rc.5

* **Bug Fixes**
  * Fixed REST idempotency replay to return the original cached response body verbatim, preserving status codes and all response fields

* **New Features**
  * Added `Idempotency-Replayed` response header to identify retried requests

* **Known Issues (Deferred to v0.4.1)**
  * Audit trails may show no rows for newly created identities without logged actions
  * Delegation capability escalation failures return error dictionaries instead of raising exceptions

* **Documentation**
  * Updated installation and quickstart guides for v0.4.0-rc.5

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VibeTensor/attestix/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->