### PR TITLE
docs(readme): add the 6-language verifier matrix (4 live, 2 publishing soon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,22 +85,27 @@ streamlit run demo/webapp/app.py         # Opens at http://localhost:8501
 python examples/quickstart.py            # Full 9-module workflow in 0.1 seconds
 ```
 
-### JS / TS verifier
+## Verify in any language
 
-Verify Attestix-issued credentials offline from JavaScript or TypeScript:
+Attestix credentials are issued once (Python core or cloud) and verify
+**anywhere**. Six independent verifier implementations share one conformance
+suite (`spec/verify/v1`) — verify offline, no Python runtime, zero trust in the
+issuer. The verifiers are verifier-only: issuance stays in the Python core.
 
-```bash
-npm install attestix
-```
+| Language | Install | Status |
+|----------|---------|--------|
+| **Python** | `pip install attestix` | live (full lib: issue + verify) |
+| **JS / TS** | `npm install attestix` | live ([attestix-js](https://github.com/VibeTensor/attestix-js)) |
+| **Go** | `go get github.com/VibeTensor/attestix-go` | live ([attestix-go](https://github.com/VibeTensor/attestix-go)) |
+| **Rust** | `cargo add attestix` | live ([attestix-rs](https://github.com/VibeTensor/attestix-rs)) |
+| **Java** | `com.vibetensor:attestix:0.4.0` | publishing soon ([attestix-java](https://github.com/VibeTensor/attestix-java)) |
+| **R** | `install.packages("attestix")` | coming to CRAN ([attestix-r](https://github.com/VibeTensor/attestix-r)) |
 
-Source: <https://github.com/VibeTensor/attestix-js> · npm: <https://www.npmjs.com/package/attestix>
-
-Same canonical-JSON form (RFC 8785) and Ed25519 verification (RFC 8032) as
-the Python core. ~68 KB packaged, one runtime dependency
-(`@noble/curves`). The pre-rename scoped name `@vibetensor/attestix` is
-deprecated — see the
-[npm rename migration guide](https://attestix.io/docs/guides/migration-npm-rename)
-if you are upgrading.
+Every verifier checks the same canonical-JSON form ([RFC 8785](https://www.rfc-editor.org/rfc/rfc8785))
+and Ed25519 signatures ([RFC 8032](https://www.rfc-editor.org/rfc/rfc8032)) against
+the shared [`spec/verify/v1`](https://github.com/VibeTensor/attestix/tree/main/spec/verify/v1)
+vectors. Verify in the browser at <https://attestix.io/verify>, or read the
+bundle wire-format at <https://attestix.io/spec/bundle/v1>.
 
 ## Why Attestix
 

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "getting-started",
+    "verifiers",
     "---Quickstart by role---",
     "quickstart",
     "examples",

--- a/website/content/docs/verifiers.mdx
+++ b/website/content/docs/verifiers.mdx
@@ -1,0 +1,73 @@
+---
+title: Verifiers — verify Attestix credentials in any language
+description: Attestix credentials are issued once and verify anywhere. Six independent verifier implementations share one conformance suite — offline, no Python runtime, zero trust in the issuer.
+---
+
+An Attestix credential is issued once — by the Python core or Attestix Cloud — and verifies **anywhere**. Six independent verifier implementations all check the same canonical-JSON form ([RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)) and the same Ed25519 signatures ([RFC 8032](https://www.rfc-editor.org/rfc/rfc8032)) against one shared conformance suite, [`spec/verify/v1`](https://github.com/VibeTensor/attestix/tree/main/spec/verify/v1).
+
+The result: a regulator, an auditor, or a peer agent can confirm a Verifiable Credential offline, with no network access and no Python runtime, and **zero trust in the issuer** — the math either checks out or it does not.
+
+> **Verifier-only.** These language ports *verify* credentials and delegations; they do not *issue*. Issuance stays in the Python core (`pip install attestix`) or in Attestix Cloud. If you need to mint credentials, use Python.
+
+## Status
+
+Four verifiers are live on their language registries today; Java and R are publishing soon.
+
+| Language | Install | Status |
+|----------|---------|--------|
+| **Python** | `pip install attestix` | Live — full library (issue + verify) |
+| **JS / TS** | `npm install attestix` | Live — [attestix-js](https://github.com/VibeTensor/attestix-js) |
+| **Go** | `go get github.com/VibeTensor/attestix-go` | Live — [attestix-go](https://github.com/VibeTensor/attestix-go) |
+| **Rust** | `cargo add attestix` | Live — [attestix-rs](https://github.com/VibeTensor/attestix-rs) |
+| **Java** | `com.vibetensor:attestix:0.4.0` | Publishing soon — [attestix-java](https://github.com/VibeTensor/attestix-java) |
+| **R** | `install.packages("attestix")` | Coming to CRAN — [attestix-r](https://github.com/VibeTensor/attestix-r) |
+
+Prefer not to install anything? Verify a credential in your browser at [attestix.io/verify](https://attestix.io/verify), or read the bundle wire-format at [attestix.io/spec/bundle/v1](https://attestix.io/spec/bundle/v1).
+
+## Code examples
+
+Each verifier exposes a `verifyCredential` entry point that takes a credential JSON and the issuer's DID document (or embedded public key) and returns a structured pass/fail result. No network calls.
+
+### Python
+
+```python
+from attestix.services.credential_service import CredentialService
+
+ok = CredentialService().verify_credential_offline(
+    credential=vc,                       # the VC JSON
+    did_document_path="did-document.json",
+)
+# -> True, or False with a reason
+```
+
+### JavaScript / TypeScript
+
+```ts
+import { verifyCredential } from "attestix";
+
+const result = await verifyCredential(vc, { didDocument });
+if (!result.valid) {
+  console.error(result.reason);
+}
+// result.valid: boolean — Ed25519 over RFC 8785 canonical JSON
+```
+
+### Go
+
+```go
+import "github.com/VibeTensor/attestix-go/verify"
+
+result, err := verify.VerifyCredential(vc, didDocument)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(result.Valid) // true if the Ed25519 signature checks out
+```
+
+## One signature, six readers
+
+Every verifier is exercised against the shared [`spec/verify/v1`](https://github.com/VibeTensor/attestix/tree/main/spec/verify/v1) vectors before release, so a credential that passes in Python passes identically in Go, Rust, or the browser. That conformance suite — not any single implementation — is the source of truth for what "valid" means.
+
+See the [Offline Verification Walkthrough](/docs/guides/offline-verify) for an end-to-end regulator scenario, and the [bundle wire-format spec](https://attestix.io/spec/bundle/v1) for the on-the-wire format.
+
+> Attestix produces cryptographically signed evidence; it is an evidence-tooling system, not a legal guarantor of compliance. Blockchain anchoring, where used, targets Base L2 (Sepolia testnet). Always consult qualified legal counsel for compliance decisions.


### PR DESCRIPTION
@
## What

The Attestix offline verifier now ships in six languages, all checked against one shared conformance suite (`spec/verify/v1`). This PR surfaces that in the main README **and** the docs site.

### README (`README.md`)
Replaces the single JS/TS verifier subsection with a **Verify in any language** section near the top:
- Language / Install / Status table
- One-sentence trust story (six independent verifiers, one shared suite, verify offline, zero trust in the issuer)
- Links to each repo, https://attestix.io/verify, and the bundle wire-format spec

### Website (`website/content/docs/verifiers.mdx`, registered in `meta.json`)
New docs page **Verifiers — verify Attestix credentials in any language**:
- Honest status table
- Per-language install command
- `verifyCredential` examples for Python + JS + Go
- Links to `/verify` (browser) and `/spec/bundle/v1` (the format)

## Honest status (4 live, 2 publishing soon)

| Language | Install | Status |
|----------|---------|--------|
| Python | `pip install attestix` | Live (full lib: issue + verify) |
| JS / TS | `npm install attestix` | Live |
| Go | `go get github.com/VibeTensor/attestix-go` | Live |
| Rust | `cargo add attestix` | Live |
| Java | `com.vibetensor:attestix:0.4.0` | Publishing soon |
| R | `install.packages("attestix")` | Coming to CRAN |

Java/R are **not** yet on Maven Central / CRAN — labelled accordingly. Verifier-only framing throughout (issuance stays Python/cloud). Evidence-tooling-not-guarantor + Sepolia-testnet caveats retained.

## Build gate

This PR touches `website/` so the Cloudflare Pages build is load-bearing.
Local `npx next build` passes: **83 static pages generated**, docs route includes the new `verifiers` page, `/verify` and `/spec/bundle/v1` routes present.

## Test plan
- [x] Local `npm install --legacy-peer-deps && npx next build` green (83 pages)
- [ ] Cloudflare Pages check SUCCESS on this PR
@