### PR TITLE
docs(accuracy): fix phantom APIs + tool/param names + stale versions (audit A7/A8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@
 </p>
 
 <p align="center">
-  <em>Status: v0.4.0-rc.3 release candidate. Single-maintainer project, community
+  <em>Status: v0.4.0 stable (pre-release 0.4.1rc1 available via the --pre channel).
+  Single-maintainer project, community
   contributions welcome. No independent third-party security audit has been
   performed yet; deploy with the same diligence you would apply to any
   pre-1.0 open-source crypto stack.</em>
@@ -43,12 +44,15 @@
 ## Install
 
 ```bash
-# v0.4.0-rc.3 is a release candidate (pre-release). Use --pre to install it:
+# Stable 0.4.0:
+pip install attestix
+
+# Pre-release 0.4.1rc1 (opt in with --pre):
 pip install --pre attestix
 ```
 
-> v0.4.0-rc.3 packaging fix: the wheel now ships only the canonical
-> `attestix.*` namespace. The pre-rc.2 flat layout (`from services... import`,
+> Stable 0.4.0 ships only the canonical
+> `attestix.*` namespace. The older flat layout (`from services... import`,
 > `from auth... import`, ...) keeps working via thin deprecation shims that
 > emit a `DeprecationWarning` on first import and are scheduled for removal in
 > v0.5.0. Update imports to `from attestix.services... import` at your earliest
@@ -262,7 +266,7 @@ Every artifact Attestix produces is cryptographically signed with Ed25519:
 ## Architecture
 
 ```
-attestix/                  # Canonical Python package (v0.4.0-rc.3)
+attestix/                  # Canonical Python package (v0.4.0)
   main.py                  # MCP server entry point (47 tools)
   cli.py                   # `attestix` console script
   config.py                # Environment-based configuration
@@ -293,7 +297,7 @@ attestix/                  # Canonical Python package (v0.4.0-rc.3)
   tools/                   # MCP tool definitions (one file per module)
 ```
 
-The pre-v0.4.0-rc.3 flat layout (`services/`, `auth/`, `storage/`, ...) is
+The pre-v0.4.0 flat layout (`services/`, `auth/`, `storage/`, ...) is
 preserved as deprecation shims at the same paths. They re-export from the
 canonical `attestix.*` namespace and emit a `DeprecationWarning` on first
 import. The shims are scheduled for removal in v0.5.0.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -302,7 +302,7 @@ Issue a W3C Verifiable Credential with Ed25519Signature2020 proof.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `subject_agent_id` | string | Yes | - | Agent this credential is about |
+| `agent_id` | string | Yes | - | Agent this credential is about |
 | `credential_type` | string | Yes | - | Type (e.g., `EUAIActComplianceCredential`) |
 | `issuer_name` | string | Yes | - | Issuing authority name |
 | `claims_json` | string | Yes | - | JSON string of claims |

--- a/website/content/docs/examples.mdx
+++ b/website/content/docs/examples.mdx
@@ -5,9 +5,9 @@ description: Runnable examples for every Attestix module, from identity creation
 
 # Examples
 
-Runnable examples for every Attestix module. All examples work standalone after `pip install --pre attestix` (v0.4.0-rc.2 release candidate) or `pip install attestix` (stable 0.3.0).
+Runnable examples for every Attestix module. All examples work standalone after `pip install attestix` (stable 0.4.0) or `pip install --pre attestix` (pre-release 0.4.1rc1).
 
-v0.4.0-rc.2 ships the canonical `attestix.*` namespace shown below. The pre-rc.2
+Stable 0.4.0 ships the canonical `attestix.*` namespace shown below. The older
 flat layout (`from services... import`) still works as a deprecation shim but is
 scheduled for removal in v0.5.0. See the [namespace migration guide](/docs/guides/migration-v0.4.0-namespace).
 

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -19,14 +19,14 @@ The [quickstart pages](/docs/quickstart) cover 10 ICP personas (indie dev, finte
 ## Installation
 
 ```bash
-# v0.4.0-rc.2 release candidate (canonical attestix.* namespace, recommended):
-pip install --pre attestix
-
-# Stable 0.3.0 (flat top-level packages, no namespace):
+# Stable 0.4.0 (canonical attestix.* namespace, recommended):
 pip install attestix
+
+# Pre-release 0.4.1rc1 (opt in with --pre):
+pip install --pre attestix
 ```
 
-v0.4.0-rc.2 ships the proper `attestix.*` namespace. The pre-rc.2 flat layout
+Stable 0.4.0 ships the proper `attestix.*` namespace. The older flat layout
 (`from services... import ...`) keeps working via deprecation shims and is
 scheduled for removal in v0.5.0. See the
 [namespace migration guide](/docs/guides/migration-v0.4.0-namespace) before

--- a/website/content/docs/guides/offline-verify.mdx
+++ b/website/content/docs/guides/offline-verify.mdx
@@ -3,7 +3,7 @@ title: Offline Verification Walkthrough
 description: How a regulator, auditor, or other agent verifies an Attestix Verifiable Credential without any network access.
 ---
 
-This guide walks through verifying an Attestix-issued Verifiable Credential with no internet connection. All that is required is the public key of the issuer, which is embedded in the DID.
+This guide walks through verifying an Attestix-issued Verifiable Credential with no internet connection. All that is required is the credential JSON itself: the issuer's public key is encoded directly in the `did:key` carried in the credential's `issuer.id`, so verification never has to fetch a DID document or call the issuer.
 
 ## Scenario
 
@@ -13,7 +13,7 @@ You are a regulator. A supplier has sent you a Declaration of Conformity VC for 
 2. The signature has not been tampered with.
 3. The audit trail behind it is internally consistent.
 
-No network calls. Everything should verify from the JSON blob and the public key.
+No network calls. Everything verifies from the JSON blob, because the issuer's Ed25519 public key is embedded in the `did:key`.
 
 ## Prerequisites
 
@@ -25,92 +25,196 @@ pip install attestix
 
 Ask the supplier to send:
 
-- The Verifiable Credential JSON (Annex V Declaration of Conformity)
-- The issuer's DID document (or the embedded public key)
-- Optionally, the hash-chained audit trail export
+- The Verifiable Credential JSON (for example an EU AI Act Declaration of Conformity).
+- Optionally, a Verifiable Presentation JSON bundling several credentials.
+- Optionally, the Article 12 audit trail entries for the agent.
 
-All three come from `export_compliance_pack`:
-
-```python
-from attestix.services.compliance_service import ComplianceService
-
-pack = ComplianceService().export_compliance_pack(
-    agent_id="attestix:f9bdb7a94ccb40f1"
-)
-# pack -> zip with credential.json, did-document.json, audit.ndjson
-```
-
-## Step 2 / Verify the signature
+These are plain JSON. The issuer's public key is not a separate file: it is the `did:key` in `credential["issuer"]["id"]`, which decodes to the raw Ed25519 verifying key. That is what makes verification self contained and offline.
 
 ```python
 import json
-from attestix.services.credential_service import CredentialService
-
-credential_svc = CredentialService()
 
 with open("credential.json") as f:
     vc = json.load(f)
 
-ok = credential_svc.verify_credential_offline(
-    credential=vc,
-    did_document_path="did-document.json",
-)
-# -> True (or False with a reason)
+print(vc["issuer"]["id"])  # did:key:z6Mk... encodes the issuer public key
+```
+
+## Step 2 / Verify the signature
+
+`verify_credential_external` verifies any credential supplied as raw JSON. It does not require the credential to be in local storage, which is exactly the external verifier case.
+
+```python
+from attestix.services.credential_service import CredentialService
+
+credential_svc = CredentialService()
+
+result = credential_svc.verify_credential_external(vc)
+# result -> {
+#   "valid": True,
+#   "credential_id": "urn:uuid:...",
+#   "type": ["VerifiableCredential", "ConformityAssessmentCredential"],
+#   "subject": "attestix:f9bdb7a94ccb40f1",
+#   "checks": {
+#       "structure_valid": True,
+#       "not_revoked": True,
+#       "not_expired": True,
+#       "signature_valid": True,
+#   },
+# }
+print(result["valid"], result["checks"])
 ```
 
 Internally this:
 
-1. Canonicalises the VC with [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) JCS.
-2. Extracts the `proofValue` field.
-3. Looks up the `verificationMethod` key in the DID document.
-4. Verifies the Ed25519 signature per [RFC 8032](https://www.rfc-editor.org/rfc/rfc8032).
+1. Confirms the object is a `VerifiableCredential`.
+2. Strips the mutable fields (`proof` and `credentialStatus`) and canonicalises the rest with the Attestix canonical JSON form (a practical subset of [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) JCS, sorted keys, no whitespace, NFC normalized).
+3. Decodes the verifying key from `issuer.id` (the trust anchor), not from `proof.verificationMethod`. If `proof.verificationMethod` names a different DID, verification fails. This blocks issuer key substitution.
+4. Verifies the Ed25519 signature in `proof.proofValue` per [RFC 8032](https://www.rfc-editor.org/rfc/rfc8032), and checks expiry and (when the revocation list is available locally) revocation.
+
+The credential is valid only when `signature_valid` AND `not_expired` AND `not_revoked` all hold. An external verifier with no revocation list assumes not revoked, so confirm revocation separately if that matters for your use case.
 
 If the signature is valid, you have cryptographic proof that the issuer controlled the private key at signing time.
 
-## Step 3 / Verify the audit chain
+## Step 3 / Verify a presentation (optional)
+
+If the supplier sent a Verifiable Presentation that bundles several credentials, verify it in one call. `verify_presentation` checks the presentation signature plus every embedded credential.
 
 ```python
+with open("presentation.json") as f:
+    vp = json.load(f)
+
+result = credential_svc.verify_presentation(vp)
+# result -> {
+#   "valid": True,
+#   "holder": "attestix:f9bdb7a94ccb40f1",
+#   "credential_count": 2,
+#   "checks": {
+#       "structure_valid": True,
+#       "vp_signature_valid": True,
+#       "credentials_valid": True,
+#       "holder_matches_subjects": True,
+#       ...
+#   },
+# }
+print(result["valid"], result["checks"])
+```
+
+Each embedded credential is verified against its own `issuer.id`, and every credential subject is checked against the presentation holder.
+
+## Step 4 / Verify the audit chain
+
+The Article 12 audit trail is a SHA-256 hash chain: each entry links to the previous one, so tampering with any row invalidates every later row. Pull the entries with `get_audit_trail`, then recompute the chain offline.
+
+```python
+import hashlib
+import json
 from attestix.services.provenance_service import ProvenanceService
 
-ok, first_bad_index = ProvenanceService().verify_audit_chain(
-    trail_path="audit.ndjson"
-)
-# -> (True, None) or (False, 42)
+entries = ProvenanceService().get_audit_trail(agent_id="attestix:f9bdb7a94ccb40f1")
+
+GENESIS = "0" * 64
+
+
+def chain_hash(previous_hash: str, entry: dict) -> str:
+    # Same rule the recorder uses: SHA-256 over "{prev_hash}:{canonical_json}"
+    # where canonical_json excludes the prev_hash, chain_hash, and signature
+    # fields and uses sorted keys with compact separators.
+    body = {
+        k: v
+        for k, v in entry.items()
+        if k not in {"prev_hash", "chain_hash", "signature"}
+    }
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(f"{previous_hash}:{canonical}".encode("utf-8")).hexdigest()
+
+
+prev = GENESIS
+first_bad = None
+for index, entry in enumerate(entries):
+    if entry.get("prev_hash") != prev or chain_hash(prev, entry) != entry.get("chain_hash"):
+        first_bad = index
+        break
+    prev = entry["chain_hash"]
+
+print("chain consistent" if first_bad is None else f"tamper at entry {first_bad}")
 ```
 
-Each entry is checked with `SHA-256(prev_hash + canonical_json(entry_without_hash_fields)) = hash`, where `canonical_json` uses sorted keys and compact separators. Any tamper with any row invalidates all subsequent rows.
-
-## Step 4 / Verify the declaration against the profile
-
-```python
-ok = ComplianceService().verify_declaration_offline(
-    declaration_path="credential.json",
-    profile_path="profile.json",
-)
-```
-
-Confirms the declaration references the correct risk category, notified body, and covered articles.
+Any change to any row, or any reordering, breaks the recomputed hash and surfaces the first bad index.
 
 ## Full example script
 
-A runnable script is included in the repo at `examples/offline_verify.py`:
+Putting the three checks together into one runnable script:
+
+```python
+# offline_verify.py
+import hashlib
+import json
+import sys
+
+from attestix.services.credential_service import CredentialService
+from attestix.services.provenance_service import ProvenanceService
+
+GENESIS = "0" * 64
+
+
+def chain_hash(previous_hash: str, entry: dict) -> str:
+    body = {
+        k: v
+        for k, v in entry.items()
+        if k not in {"prev_hash", "chain_hash", "signature"}
+    }
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(f"{previous_hash}:{canonical}".encode("utf-8")).hexdigest()
+
+
+def main(vc_path: str, agent_id: str) -> int:
+    with open(vc_path) as f:
+        vc = json.load(f)
+
+    result = CredentialService().verify_credential_external(vc)
+    if not result.get("valid"):
+        print(f"[fail] credential not valid: {result.get('checks')}")
+        return 1
+    print(f"[ok] signature verified (issuer {vc['issuer']['id']})")
+
+    entries = ProvenanceService().get_audit_trail(agent_id=agent_id)
+    prev = GENESIS
+    for index, entry in enumerate(entries):
+        if entry.get("prev_hash") != prev or chain_hash(prev, entry) != entry.get("chain_hash"):
+            print(f"[fail] audit chain broken at entry {index}")
+            return 1
+        prev = entry["chain_hash"]
+    print(f"[ok] audit chain consistent ({len(entries)} entries)")
+
+    print("VERIFY = PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1], sys.argv[2]))
+```
+
+Run it:
 
 ```bash
-python examples/offline_verify.py ./compliance-pack.zip
+python offline_verify.py ./credential.json attestix:f9bdb7a94ccb40f1
 ```
 
 Output:
 
 ```
-[ok] signature verified (Ed25519Signature2020)
-[ok] audit chain consistent (1,247 entries)
-[ok] declaration references profile:3c8f21e9
-[ok] 9 / 9 obligations met (Articles 9, 10, 11, 12, 13, 14, 15, 43, Annex V)
+[ok] signature verified (issuer did:key:z6Mk...)
+[ok] audit chain consistent (1247 entries)
 VERIFY = PASS
 ```
+
+## Verify without Python
+
+The same credential verifies in any language. Six independent verifier implementations share one conformance suite at [`spec/verify/v1`](https://github.com/VibeTensor/attestix/tree/main/spec/verify/v1), so a Go, Rust, JS, Java, or R verifier reaches the identical verdict on the identical canonical bytes. You can also verify a credential in the browser at [attestix.io/verify](https://attestix.io/verify). Issuance stays in the Python core; verification is open and portable.
 
 ## Why this matters
 
 Every other compliance artefact you receive as a regulator comes as a PDF or a dashboard screenshot. Neither is cryptographically bindable to a specific operator or point in time. Attestix artefacts are.
 
-The same function is what a peer agent calls when it decides whether to trust another agent's capability claim. See [UCAN delegation](/docs/guides/integration-guide) for how delegation chains are verified the same way.
+The same verification is what a peer agent runs when it decides whether to trust another agent's capability claim. See [UCAN delegation](/docs/guides/integration-guide) for how delegation chains are verified the same way.

--- a/website/content/docs/reference/api-reference.mdx
+++ b/website/content/docs/reference/api-reference.mdx
@@ -307,7 +307,7 @@ Issue a W3C Verifiable Credential with Ed25519Signature2020 proof.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `subject_agent_id` | string | Yes | - | Agent this credential is about |
+| `agent_id` | string | Yes | - | Agent this credential is about |
 | `credential_type` | string | Yes | - | Type (e.g., `EUAIActComplianceCredential`) |
 | `issuer_name` | string | Yes | - | Issuing authority name |
 | `claims_json` | string | Yes | - | JSON string of claims |

--- a/website/content/docs/reference/mcp-tools.mdx
+++ b/website/content/docs/reference/mcp-tools.mdx
@@ -25,7 +25,7 @@ Unified Agent Identity Tokens bridging MCP OAuth, A2A, DIDs, and API keys.
 | `revoke_identity` | Revoke an identity (soft delete with audit entry) |
 | `translate_identity` | Translate between UAIT formats (MCP, A2A, DID, OAuth) |
 | `resolve_identity` | Resolve an agent by DID or agent card URL |
-| `erase_identity` | GDPR Article 17 hard delete with tombstone |
+| `purge_agent_data` | GDPR Article 17 right to erasure: permanently delete all data for an agent |
 
 ## 02 / Agent Cards (3 tools)
 
@@ -80,7 +80,7 @@ EU AI Act risk profiles, Article 43 conformity, Annex V declarations.
 | `record_conformity_assessment` | Record Article 43 assessment (blocks self on high-risk) |
 | `get_compliance_status` | Get the current completeness status |
 | `generate_declaration_of_conformity` | Generate Annex V declaration as a W3C VC |
-| `export_compliance_pack` | Bundle profile + evidence + declaration for regulators |
+| `update_compliance_profile` | Iteratively update an existing profile (only non-empty fields change) |
 
 ## 07 / Credentials (8 tools)
 
@@ -95,7 +95,7 @@ W3C Verifiable Credentials 1.1 with Ed25519Signature2020.
 | `revoke_credential` | Revoke a credential with reason code |
 | `create_verifiable_presentation` | Bundle VCs into a VP with audience binding |
 | `verify_presentation` | Verify a VP including replay protection |
-| `export_credential` | Export a VC as JSON or JWT |
+| `verify_credential_external` | Verify a VC supplied as raw JSON, without local storage |
 
 ## 08 / Provenance (5 tools)
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Attestation Infrastructure for AI Agents. Cryptographic proof your AI agents are compliant with the EU AI Act.
 
-Attestix provides verifiable identity, W3C credentials, delegation chains, compliance declarations, provenance tracking, reputation scoring, and Base L2 testnet anchoring for autonomous AI agents. 47 MCP tools across 9 modules. 481 automated tests (390 functional + 91 RFC / W3C conformance benchmarks). Apache 2.0. v0.4.0-rc.2 release candidate; single-maintainer project; no independent third-party security audit yet.
+Attestix provides verifiable identity, W3C credentials, delegation chains, compliance declarations, provenance tracking, reputation scoring, and Base L2 testnet anchoring for autonomous AI agents. 47 MCP tools across 9 modules. 481 automated tests (390 functional + 91 RFC / W3C conformance benchmarks). Apache 2.0. Stable 0.4.0 (pre-release 0.4.1rc1 via pip install --pre attestix); single-maintainer project; no independent third-party security audit yet.
 
 ## Marketing
 
@@ -14,7 +14,7 @@ Attestix provides verifiable identity, W3C credentials, delegation chains, compl
 - [Community](https://attestix.io/community): GitHub, contributing, resources
 - [Blog](https://attestix.io/blog): Release notes and field reports
 - [Research](https://attestix.io/research): Paper abstract, contributions, evaluation
-- [Changelog](https://attestix.io/changelog): v0.1.0 through v0.3.0 release history
+- [Changelog](https://attestix.io/changelog): v0.1.0 through v0.4.0 release history
 - [Verify a credential](https://attestix.io/verify): Client-side W3C Verifiable Credential verifier — paste or drop a VC and check its Ed25519 signature, structure, and validity window entirely in-browser via the @vibetensor/attestix npm package. Nothing uploaded; no backend. By-id deep link form is /verify?id=<credential-id> (by-id resolution itself is an Attestix Cloud feature). Live revocation not checked offline.
 - [Security](https://attestix.io/security): Responsible disclosure, CVE process
 - [SBOM](https://attestix.io/sbom): Software bill of materials with licenses

--- a/website/src/lib/atx-data.ts
+++ b/website/src/lib/atx-data.ts
@@ -1,7 +1,7 @@
 /*
  * Attestix v2 landing data.
  * Numbers here are the real project surface:
- *   - v0.4.0-rc.2 release candidate, 481 tests (390 functional + 91 conformance benchmarks),
+ *   - Stable 0.4.0, 481 tests (390 functional + 91 conformance benchmarks),
  *     47 MCP tools, 9 modules, 44 REST endpoints. Single-maintainer project.
  *   - Base L2 is testnet (integration complete, mainnet schema not yet registered).
  *   - Real framework integrations: LangChain, OpenAI Agents SDK, CrewAI.

--- a/website/src/lib/config.tsx
+++ b/website/src/lib/config.tsx
@@ -3,7 +3,7 @@ import { Icons } from "@/components/icons";
 export const BLUR_FADE_DELAY = 0.15;
 
 export const ATTESTIX_VERSION =
-  process.env.NEXT_PUBLIC_ATTESTIX_VERSION || "0.3.0";
+  process.env.NEXT_PUBLIC_ATTESTIX_VERSION || "0.4.0";
 
 export const siteConfig = {
   name: "Attestix",
@@ -34,8 +34,8 @@ export const siteConfig = {
     title: "Attestix",
     description:
       "The EU AI Act takes effect August 2, 2026. Non-compliant organizations face fines up to EUR 35 million or 7% of global revenue. Attestix is like TurboTax for AI compliance: it automates the documentation, identity verification, and audit trails your AI agents need to stay legal. Install once, drop into LangChain, OpenAI Agents SDK, or CrewAI, and generate cryptographic proof of compliance on every run.",
-    cta: "pip install --pre attestix",
-    ctaDescription: "v0.4.0-rc.2 release candidate - 481 tests passing (390 functional + 91 RFC / W3C conformance benchmarks). Real LangChain, OpenAI Agents SDK, and CrewAI integrations. Apache 2.0. Single-maintainer project; no independent third-party security audit yet.",
+    cta: "pip install attestix",
+    ctaDescription: "Stable 0.4.0 - 481 tests passing (390 functional + 91 RFC / W3C conformance benchmarks). Real LangChain, OpenAI Agents SDK, and CrewAI integrations. Apache 2.0. Single-maintainer project; no independent third-party security audit yet.",
   },
   // 4-tier model. Single source of truth: attestix-cloud-plan/18-TIER-MATRIX.md
   // (OSS free, self-host / Cloud Free / Cloud Pro / Cloud Enterprise).
@@ -278,12 +278,12 @@ export const siteConfig = {
     {
       question: "What is the current maturity level?",
       answer:
-        `Attestix v${ATTESTIX_VERSION} is a release candidate (v0.4.0-rc.2) under active development. It includes 481 tests across functional, end-to-end, and conformance benchmark suites (390 functional + 91 RFC / W3C conformance) covering all 9 modules, plus real integrations with LangChain, OpenAI Agents SDK, and CrewAI. GitHub Actions CI runs the full pytest matrix, lint, and security scans on every push. Single-maintainer project; no independent third-party security audit has been performed yet. Treat it as you would any pre-1.0 open-source crypto stack: pin the version, review the diff, and test thoroughly before relying on it in production.`,
+        `Attestix v${ATTESTIX_VERSION} is the current stable release under active development (pre-release 0.4.1rc1 is available via pip install --pre attestix). It includes 481 tests across functional, end-to-end, and conformance benchmark suites (390 functional + 91 RFC / W3C conformance) covering all 9 modules, plus real integrations with LangChain, OpenAI Agents SDK, and CrewAI. GitHub Actions CI runs the full pytest matrix, lint, and security scans on every push. Single-maintainer project; no independent third-party security audit has been performed yet. Treat it as you would any pre-1.0 open-source crypto stack: pin the version, review the diff, and test thoroughly before relying on it in production.`,
     },
     {
       question: "Does Attestix work with LangChain, OpenAI Agents SDK, or CrewAI?",
       answer:
-        "Yes, all three are real integrations shipped in v0.3.0 rather than examples or shims. LangChain uses a BaseCallbackHandler that writes every tool call, LLM call, and chain step to the Attestix audit trail with hash chaining. OpenAI Agents SDK uses MCPServerStdio so Attestix tools appear as native MCP tools. CrewAI attaches Attestix to the mcps field on every agent, giving each crew member full attestation capabilities. You can also use Attestix via its MCP server from any MCP-compatible client (Claude Desktop, Cursor, Continue, Windsurf, VS Code).",
+        "Yes, all three are real integrations rather than examples or shims. LangChain uses a BaseCallbackHandler that writes every tool call, LLM call, and chain step to the Attestix audit trail with hash chaining. OpenAI Agents SDK uses MCPServerStdio so Attestix tools appear as native MCP tools. CrewAI attaches Attestix to the mcps field on every agent, giving each crew member full attestation capabilities. You can also use Attestix via its MCP server from any MCP-compatible client (Claude Desktop, Cursor, Continue, Windsurf, VS Code).",
     },
     {
       question: "How does blockchain anchoring work?",


### PR DESCRIPTION
Code-verified accuracy fixes from the audit:
- **mcp-tools.mdx**: 3 non-existent tool names replaced with real registered ones (verified against `attestix/tools/*.py`).
- **api-reference** (.mdx + .md): `issue_credential` param `subject_agent_id` -> `agent_id`.
- **offline-verify.mdx**: rewritten against the REAL API (`verify_credential_external`, `verify_presentation`, `get_audit_trail` + offline chain recompute); 4 phantom methods + phantom script removed.
- **version labels** (6 files): rc.2/rc.3 -> stable 0.4.0 + 0.4.1rc1 on --pre; correct install commands.

Each agent verified claims against source before editing. No em/en-dashes introduced. Part of the commercialization loop.