### PR TITLE
fix(deps): bump cryptography >=48.0.1 (GHSA-537c-gmf6-5ccf, green the Security CI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,10 @@ dependencies = [
     # cryptography 47.x, etc.) on fresh `pip install attestix`. See
     # paper/internal/dependency-audit-v0.3.0-2026-04-17.md for the rationale.
     "mcp[cli]>=1.8.0,<2.0.0",
-    # cryptography >=46.0.7 closes CVE-2026-34073 (name constraints bypass)
-    # and CVE-2026-39892 (Hash.update buffer overflow).
-    "cryptography>=46.0.7,<47.0.0",
+    # cryptography >=48.0.1 closes GHSA-537c-gmf6-5ccf (in addition to the
+    # earlier CVE-2026-34073 name-constraints bypass and CVE-2026-39892
+    # Hash.update buffer overflow closed in 46.0.7).
+    "cryptography>=48.0.1,<50.0.0",
     # PyJWT >=2.12.0 closes CVE-2026-32597 (crit header validation bypass).
     # This directly impacts Attestix's JWT / Verifiable Credential / UCAN
     # verification paths and is the hard blocker for the v0.3.0 release.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@
 mcp[cli]>=1.8.0
 
 # Cryptography
-# Floors MUST match pyproject.toml: cryptography>=46.0.7 closes
-# CVE-2026-34073 (name-constraints bypass); PyJWT>=2.12.0 closes
-# CVE-2026-32597 (crit-header validation bypass). Upper bounds prevent
-# silent major-version drift on installs from this file (e.g. Docker builds).
-cryptography>=46.0.7,<47.0.0
+# Floors MUST match pyproject.toml: cryptography>=48.0.1 closes
+# GHSA-537c-gmf6-5ccf (plus earlier CVE-2026-34073 name-constraints bypass);
+# PyJWT>=2.12.0 closes CVE-2026-32597 (crit-header validation bypass). Upper
+# bounds prevent silent major-version drift on installs from this file.
+cryptography>=48.0.1,<50.0.0
 PyJWT[crypto]>=2.12.0,<3.0.0
 base58>=2.1.1
 


### PR DESCRIPTION
CI Security workflow (pip-audit) is red on main: cryptography 46.0.7 has GHSA-537c-gmf6-5ccf (fix 48.0.1); the old <47 ceiling pinned us to the vulnerable line. Floor+ceiling now >=48.0.1,<50.0.0 (installs 49.0.0). 295 tests pass locally; cryptography clears pip-audit.