### PR TITLE
feat(pqc): ML-DSA-65 + hybrid Ed25519+ML-DSA post-quantum signing (optional, additive)

### DIFF
--- a/attestix/auth/pqc.py
+++ b/attestix/auth/pqc.py
@@ -1,0 +1,147 @@
+"""Post-quantum and hybrid signing for Attestix (FIPS 204 ML-DSA-65).
+
+OPTIONAL module. It requires the ``[pqc]`` extra (``pip install attestix[pqc]``),
+which pulls in ``dilithium-py`` (a pure-Python ML-DSA implementation, so it adds
+no native-build burden and keeps the verifier portable). The classical Ed25519
+path in :mod:`attestix.auth.crypto` is unchanged and remains the default; nothing
+here touches it.
+
+What this adds, additively:
+
+- **ML-DSA-65** (FIPS 204) sign / verify over the same JCS canonical form the
+  Ed25519 path uses, so the signed bytes are identical across suites.
+- A **hybrid composite** (Ed25519 + ML-DSA-65) where a verifier MUST validate
+  BOTH signatures. This "weak non-separability" defeats signature stripping: an
+  attacker who breaks one algorithm still cannot forge a valid composite, and a
+  downgrade to the classical-only half is rejected. It mirrors the IETF
+  composite-signature and W3C ``di-quantum-safe`` direction, letting Attestix
+  issue classical-today / quantum-safe-tomorrow credentials without re-issuing
+  identities ("harvest-now, decrypt-later" does not touch a hybrid attestation).
+- ``did:key`` Multikey encoding for ML-DSA-65 (multicodec ``0x1211``).
+
+Cryptosuite identifiers (for Data Integrity proofs and conformance vectors):
+
+- ``mldsa65-jcs-2026``                 : pure ML-DSA-65.
+- ``hybrid-ed25519-mldsa65-jcs-2026``  : Ed25519 + ML-DSA-65 composite.
+"""
+from __future__ import annotations
+
+import base64
+from typing import Tuple
+
+import base58
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from attestix.auth.crypto import (
+    canonicalize_json,
+    sign_json_payload,
+    verify_json_signature,
+)
+
+SUITE_MLDSA65 = "mldsa65-jcs-2026"
+SUITE_HYBRID = "hybrid-ed25519-mldsa65-jcs-2026"
+
+# Multicodec code 0x1211 (ml-dsa-65-pub) encoded as an unsigned LEB128 varint.
+MLDSA65_MULTICODEC_PREFIX = bytes([0x91, 0x24])
+
+# Separator between the two halves of a hybrid proof value. Chosen because it is
+# absent from both the base64url and standard-base64 alphabets, so it can never
+# collide with either signature encoding.
+_HYBRID_SEP = "~"
+
+
+def _ml_dsa():
+    """Return the ML-DSA-65 implementation, or raise a clear install hint."""
+    try:
+        from dilithium_py.ml_dsa import ML_DSA_65
+
+        return ML_DSA_65
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "Post-quantum signing requires the [pqc] extra: "
+            "pip install attestix[pqc]"
+        ) from exc
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64u_decode(text: str) -> bytes:
+    return base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
+
+
+def generate_mldsa_keypair() -> Tuple[bytes, bytes]:
+    """Generate an ML-DSA-65 keypair. Returns ``(public_bytes, secret_bytes)``."""
+    public_key, secret_key = _ml_dsa().keygen()
+    return public_key, secret_key
+
+
+def mldsa_sign(secret_key: bytes, payload: dict) -> str:
+    """Sign ``payload`` (JCS-canonicalized) with ML-DSA-65; return base64url."""
+    signature = _ml_dsa().sign(secret_key, canonicalize_json(payload))
+    return _b64u(signature)
+
+
+def mldsa_verify(public_key: bytes, payload: dict, signature_b64: str) -> bool:
+    """Verify an ML-DSA-65 signature over the canonical ``payload``."""
+    try:
+        return bool(
+            _ml_dsa().verify(
+                public_key, canonicalize_json(payload), _b64u_decode(signature_b64)
+            )
+        )
+    except Exception:
+        return False
+
+
+def hybrid_sign(
+    ed_private: Ed25519PrivateKey, mldsa_secret: bytes, payload: dict
+) -> str:
+    """Produce a composite Ed25519 + ML-DSA-65 proof value: ``<ed>~<mldsa>``.
+
+    Both halves sign the SAME JCS-canonical bytes of ``payload``.
+    """
+    ed_sig = sign_json_payload(ed_private, payload)
+    pq_sig = mldsa_sign(mldsa_secret, payload)
+    return f"{ed_sig}{_HYBRID_SEP}{pq_sig}"
+
+
+def hybrid_verify(
+    ed_public: Ed25519PublicKey,
+    mldsa_public: bytes,
+    payload: dict,
+    proof_value: str,
+) -> bool:
+    """Verify a composite proof. BOTH signatures MUST validate (anti-stripping).
+
+    Returns False if either half is missing, malformed, or invalid, so a proof
+    cannot be downgraded to a single algorithm.
+    """
+    if _HYBRID_SEP not in proof_value:
+        return False
+    ed_sig, _, pq_sig = proof_value.partition(_HYBRID_SEP)
+    if not ed_sig or not pq_sig:
+        return False
+    return verify_json_signature(ed_public, payload, ed_sig) and mldsa_verify(
+        mldsa_public, payload, pq_sig
+    )
+
+
+def mldsa_public_key_to_did_key(public_key: bytes) -> str:
+    """did:key for an ML-DSA-65 public key (multicodec 0x1211 + base58btc)."""
+    encoded = base58.b58encode(MLDSA65_MULTICODEC_PREFIX + public_key).decode("ascii")
+    return f"did:key:z{encoded}"
+
+
+def did_key_to_mldsa_public_key(did: str) -> bytes:
+    """Extract the ML-DSA-65 public key bytes from an ML-DSA ``did:key``."""
+    if not did.startswith("did:key:z"):
+        raise ValueError(f"Invalid did:key format: {did}")
+    decoded = base58.b58decode(did[len("did:key:z"):])
+    if decoded[: len(MLDSA65_MULTICODEC_PREFIX)] != MLDSA65_MULTICODEC_PREFIX:
+        raise ValueError("Not an ML-DSA-65 did:key (wrong multicodec prefix)")
+    return decoded[len(MLDSA65_MULTICODEC_PREFIX):]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,11 @@ dependencies = [
 [project.optional-dependencies]
 blockchain = ["web3>=7.0.0,<8.0.0"]
 reports = ["weasyprint>=62.0"]
+# Post-quantum signing (FIPS 204 ML-DSA-65 + hybrid Ed25519+ML-DSA). Optional,
+# never required: the default install stays classical Ed25519. dilithium-py is
+# pure-Python (no native build) so the verifier stays portable. See
+# attestix.auth.pqc.
+pqc = ["dilithium-py>=1.0.0,<2.0.0"]
 # v0.4.0 extensibility extras. The default install stays file-storage +
 # in-process Ed25519 signer with no external services (constitution: "Optional,
 # never required"). These extras are only needed for the non-default Repository /

--- a/tests/unit/test_pqc.py
+++ b/tests/unit/test_pqc.py
@@ -1,0 +1,84 @@
+"""Tests for the post-quantum / hybrid signing module (attestix.auth.pqc).
+
+Skipped unless the [pqc] extra (dilithium-py) is installed.
+"""
+
+import pytest
+
+pytest.importorskip("dilithium_py", reason="requires the [pqc] extra (dilithium-py)")
+
+from attestix.auth.crypto import generate_ed25519_keypair, public_key_to_did_key
+from attestix.auth import pqc
+
+
+PAYLOAD = {"id": "urn:uuid:1", "claim": "agent-is-authorized", "n": 7}
+
+
+class TestMlDsa:
+    def test_sign_verify_roundtrip(self):
+        pub, sec = pqc.generate_mldsa_keypair()
+        sig = pqc.mldsa_sign(sec, PAYLOAD)
+        assert pqc.mldsa_verify(pub, PAYLOAD, sig) is True
+
+    def test_tampered_payload_rejected(self):
+        pub, sec = pqc.generate_mldsa_keypair()
+        sig = pqc.mldsa_sign(sec, PAYLOAD)
+        assert pqc.mldsa_verify(pub, {**PAYLOAD, "claim": "tampered"}, sig) is False
+
+    def test_wrong_key_rejected(self):
+        _, sec = pqc.generate_mldsa_keypair()
+        other_pub, _ = pqc.generate_mldsa_keypair()
+        sig = pqc.mldsa_sign(sec, PAYLOAD)
+        assert pqc.mldsa_verify(other_pub, PAYLOAD, sig) is False
+
+    def test_did_key_roundtrip(self):
+        pub, _ = pqc.generate_mldsa_keypair()
+        did = pqc.mldsa_public_key_to_did_key(pub)
+        assert did.startswith("did:key:z")
+        assert pqc.did_key_to_mldsa_public_key(did) == pub
+
+    def test_did_key_rejects_ed25519(self):
+        _, ed_pub = generate_ed25519_keypair()
+        ed_did = public_key_to_did_key(ed_pub)
+        with pytest.raises(ValueError):
+            pqc.did_key_to_mldsa_public_key(ed_did)
+
+
+class TestHybridAntiStripping:
+    def _keys(self):
+        ed_priv, ed_pub = generate_ed25519_keypair()
+        pq_pub, pq_sec = pqc.generate_mldsa_keypair()
+        return ed_priv, ed_pub, pq_pub, pq_sec
+
+    def test_hybrid_roundtrip(self):
+        ed_priv, ed_pub, pq_pub, pq_sec = self._keys()
+        proof = pqc.hybrid_sign(ed_priv, pq_sec, PAYLOAD)
+        assert "~" in proof
+        assert pqc.hybrid_verify(ed_pub, pq_pub, PAYLOAD, proof) is True
+
+    def test_tampered_payload_rejected(self):
+        ed_priv, ed_pub, pq_pub, pq_sec = self._keys()
+        proof = pqc.hybrid_sign(ed_priv, pq_sec, PAYLOAD)
+        assert pqc.hybrid_verify(ed_pub, pq_pub, {**PAYLOAD, "n": 8}, proof) is False
+
+    def test_cannot_strip_to_ed25519_only(self):
+        # Drop the ML-DSA half: a downgraded classical-only proof must NOT verify.
+        ed_priv, ed_pub, pq_pub, pq_sec = self._keys()
+        proof = pqc.hybrid_sign(ed_priv, pq_sec, PAYLOAD)
+        ed_only = proof.split("~", 1)[0]
+        assert pqc.hybrid_verify(ed_pub, pq_pub, PAYLOAD, ed_only) is False
+        assert pqc.hybrid_verify(ed_pub, pq_pub, PAYLOAD, ed_only + "~") is False
+
+    def test_cannot_strip_to_mldsa_only(self):
+        ed_priv, ed_pub, pq_pub, pq_sec = self._keys()
+        proof = pqc.hybrid_sign(ed_priv, pq_sec, PAYLOAD)
+        pq_only = proof.split("~", 1)[1]
+        assert pqc.hybrid_verify(ed_pub, pq_pub, PAYLOAD, "~" + pq_only) is False
+
+    def test_forged_pq_half_rejected(self):
+        # Valid Ed25519 half + a PQ signature from a DIFFERENT key must fail.
+        ed_priv, ed_pub, pq_pub, pq_sec = self._keys()
+        _, other_sec = pqc.generate_mldsa_keypair()
+        ed_sig = pqc.hybrid_sign(ed_priv, pq_sec, PAYLOAD).split("~", 1)[0]
+        forged = f"{ed_sig}~{pqc.mldsa_sign(other_sec, PAYLOAD)}"
+        assert pqc.hybrid_verify(ed_pub, pq_pub, PAYLOAD, forged) is False


### PR DESCRIPTION
The #1 gap every competitive analysis flagged: Attestix was classical-only. This adds a real post-quantum foundation, additively and behind an optional extra, with the stable Ed25519 path untouched.

## What
- `attestix/auth/pqc.py`:
  - **ML-DSA-65** (FIPS 204) sign/verify over the same JCS canonical bytes as Ed25519.
  - **Hybrid composite** (`Ed25519 + ML-DSA-65`) where a verifier MUST validate BOTH signatures (weak non-separability). Defeats signature-stripping and classical-downgrade attacks.
  - `did:key` Multikey for ML-DSA-65 (multicodec `0x1211`).
  - Cryptosuites: `mldsa65-jcs-2026`, `hybrid-ed25519-mldsa65-jcs-2026`.
- New optional extra `attestix[pqc]` → `dilithium-py` (pure Python, no native build; verifier stays portable).

## Why
Every peer (Microsoft AGT, A2A) is classical-only; C2PA/Sigstore/IOTA are mid-migration. Shipping hybrid first flips our stated weakness into "first PQC-ready agent attestation." A hybrid attestation survives a quantum break, protecting long-lived EU AI Act evidence from harvest-now-decrypt-later.

## Safety
Additive and optional. The default install and the `Ed25519Signature2020` path are unchanged. 10 new tests pass, including anti-stripping (cannot strip to Ed25519-only or ML-DSA-only; forged PQ half rejected); the existing suite is unaffected.

## Not yet (follow-ups)
Cryptosuite registry into the `Signer`/credential proof path; PQC conformance vectors at `spec/verify/v1` so all six verifiers validate them; SLH-DSA option for long-retention anchors.

New cryptographic code — opened for review rather than auto-merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional post-quantum cryptographic signing support, installable via the `pqc` extra.
  * Introduced hybrid signing combining quantum-resistant and classical signatures for forward-compatible authentication.
  * Added DID key format support for quantum-safe public keys.

* **Tests**
  * Added comprehensive unit tests for post-quantum signing and anti-tampering protections in hybrid signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->