### PR TITLE
ci(dependabot): exclude majors from the python group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,13 @@ updates:
       python-dependencies:
         patterns:
           - "*"
+        # Keep majors OUT of the grouped PR: a single incompatible major
+        # (chardet 5->7 in PR #169) made the whole 35-package group
+        # unresolvable and failed CI. Majors must be individual, tested PRs
+        # (mirrors the npm group policy below).
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
Fixes the root cause of #169: chardet 5->7 (a major) made the 35-package grouped bump unresolvable. Restrict the python group to minor+patch so majors come as individual PRs (mirrors the npm group policy). Config-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings so grouped Python dependency pull requests now include only minor and patch versions.
  * Major version updates will be kept separate from grouped updates for clearer review and safer upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->